### PR TITLE
Allow passing custom props to the render method

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,31 @@ const components: PortableTextComponents = {
 }
 ```
 
+## Passing in custom props
+
+You can pass in custom props whenever components need to access shared data, such as data from a hook. For example, theming metadata, conditional rendering based on a user's authentication status, handling window resize events, etc:
+
+```jsx
+const myPortableTextComponents = {
+  types: {
+    myCustomComponent: ({ children, customProps }) => <p>
+      {children}
+      {!customProps?.authenticated && <span>A custom message for users who are not logged in...</span>}
+    </p>,
+  },
+}
+
+const YourComponent = (props) => {
+  const [authenticated] = useAuthentication();
+
+  return <PortableText
+    value={props.value}
+    components={myPortableTextComponents}
+    customProps={{ authenticated }}
+    />
+}
+```
+
 ## License
 
 MIT © [Sanity.io](https://www.sanity.io/)

--- a/src/react-portable-text.tsx
+++ b/src/react-portable-text.tsx
@@ -112,7 +112,7 @@ const getNodeRenderer = (
     node: PortableTextListItemBlock<PortableTextMarkDefinition, PortableTextSpan>,
     index: number,
     key: string,
-    customProps: unknown
+    customProps: any
   ) {
     const tree = serializeBlock({node, index, isInline: false, renderNode, customProps})
     const renderer = components.listItem
@@ -141,7 +141,7 @@ const getNodeRenderer = (
     )
   }
 
-  function renderList(node: ReactPortableTextList, index: number, key: string, customProps: unknown) {
+  function renderList(node: ReactPortableTextList, index: number, key: string, customProps: any) {
     const children = node.children.map((child, childIndex) =>
       renderNode({
         node: child._key ? child : {...child, _key: `li-${index}-${childIndex}`},
@@ -168,7 +168,7 @@ const getNodeRenderer = (
     )
   }
 
-  function renderSpan(node: ToolkitNestedPortableTextSpan, _index: number, key: string, customProps: unknown) {
+  function renderSpan(node: ToolkitNestedPortableTextSpan, _index: number, key: string, customProps: any) {
     const {markDef, markType, markKey} = node
     const Span = components.marks[markType] || components.unknownMark
     const children = node.children.map((child, childIndex) =>
@@ -194,7 +194,7 @@ const getNodeRenderer = (
     )
   }
 
-  function renderBlock(node: PortableTextBlock, index: number, key: string, isInline: boolean, customProps: unknown) {
+  function renderBlock(node: PortableTextBlock, index: number, key: string, isInline: boolean, customProps: any) {
     const {_key, ...props} = serializeBlock({node, index, isInline, renderNode, customProps})
     const style = props.node.style || 'normal'
     const handler =
@@ -220,7 +220,7 @@ const getNodeRenderer = (
     return node.text
   }
 
-  function renderCustomBlock(node: TypedObject, index: number, key: string, isInline: boolean, customProps: unknown) {
+  function renderCustomBlock(node: TypedObject, index: number, key: string, isInline: boolean, customProps: any) {
     const Node = components.types[node._type]
 
     const nodeOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -296,7 +296,7 @@ export interface PortableTextMarkComponentProps<M extends TypedObject = Arbitrar
  * Any node type that we can't identify - eg it has an `_type`,
  * but we don't know anything about its other properties
  */
-export type UnknownNodeType = {[key: string]: any; _type: string} | TypedObject
+export type UnknownNodeType = {[key: string]: unknown; _type: string} | TypedObject
 
 /**
  * Function that renders any node that might appear in a portable text array or block,

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,13 @@ export interface PortableTextProps<
    * You rarely (if ever) need/want to customize this
    */
   listNestingMode?: ToolkitListNestMode
+
+  /**
+   * Additional custom props passed into the render method of each component.
+   * This is helpful for situations that require shared data, such as hook
+   * data.
+   */
+  customProps?: any
 }
 
 /**
@@ -223,6 +230,13 @@ export interface PortableTextComponentProps<T> {
    * to use this.
    */
   renderNode: NodeRenderer
+
+  /**
+   * Additional custom props passed into the render method of each component.
+   * This is helpful for situations that require shared data, such as hook
+   * data.
+   */
+  customProps?: any
 }
 
 /**
@@ -269,13 +283,20 @@ export interface PortableTextMarkComponentProps<M extends TypedObject = Arbitrar
    * to use this.
    */
   renderNode: NodeRenderer
+
+  /**
+   * Additional custom props passed into the render method of each component.
+   * This is helpful for situations that require shared data, such as hook
+   * data.
+   */
+  customProps?: any
 }
 
 /**
  * Any node type that we can't identify - eg it has an `_type`,
  * but we don't know anything about its other properties
  */
-export type UnknownNodeType = {[key: string]: unknown; _type: string} | TypedObject
+export type UnknownNodeType = {[key: string]: any; _type: string} | TypedObject
 
 /**
  * Function that renders any node that might appear in a portable text array or block,
@@ -295,6 +316,7 @@ export interface Serializable<T> {
   index: number
   isInline: boolean
   renderNode: NodeRenderer
+  customProps: any
 }
 
 export interface SerializedBlock {
@@ -303,6 +325,7 @@ export interface SerializedBlock {
   index: number
   isInline: boolean
   node: PortableTextBlock | PortableTextListItemBlock
+  customProps: any
 }
 
 // Re-exporting these as we don't want to refer to "toolkit" outside of this module

--- a/test/components.test.tsx
+++ b/test/components.test.tsx
@@ -31,3 +31,29 @@ tap.test('can override unknown mark component', (t) => {
   )
   t.end()
 })
+
+tap.test('can receive custom props', (t) => {
+  const result = render({
+    value: {
+      _type: 'block',
+      children: [
+        {_type: 'span', text: 'simple'},
+      ],
+    },
+    components: {
+      block: {
+        normal: ({customProps}) => (
+          <span className="custom">
+            {customProps.text}
+          </span>
+        ),
+      },
+    },
+    customProps: {text: 'Hello World'}
+  })
+  t.same(
+    result,
+    '<span class="custom">Hello World</span>'
+  )
+  t.end()
+})

--- a/test/portable-text.test.tsx
+++ b/test/portable-text.test.tsx
@@ -297,6 +297,7 @@ tap.test('can specify custom component for custom block types', (t) => {
         },
         index: 0,
         isInline: false,
+        customProps: undefined
       })
       return (
         <pre data-language={props.value.language}>


### PR DESCRIPTION

Allow components to receive optional custom props. This is extremely helpful when components need to access shared data such as data from a hook, or anything that might be needed for additional render logic. For example, theming metadata, additional rendering logic based on a user's authentication status, handling window resize events, etc.

Example usage:

```jsx
const myPortableTextComponents = {
  types: {
    myCustomComponent: ({ children, customProps }) => <p>
      {children}
      {!customProps?.authenticated && <span>A custom message for users who are not logged in...</span>}
    </p>,
  },
}

const YourComponent = (props) => {
  const [authenticated] = useAuthentication();

  return <PortableText
    value={props.value}
    components={myPortableTextComponents}
    customProps={{ authenticated }}
    />
}
```