### PR TITLE
fix: set list child index correctly

### DIFF
--- a/src/react-portable-text.tsx
+++ b/src/react-portable-text.tsx
@@ -136,7 +136,7 @@ const getNodeRenderer = (
     const children = node.children.map((child, childIndex) =>
       renderNode({
         node: child._key ? child : {...child, _key: `li-${index}-${childIndex}`},
-        index: index,
+        index: childIndex,
         isInline: false,
         renderNode,
       })


### PR DESCRIPTION
## The bug

The list item index is set to be the the _parent_ index, not the child index.

This makes no difference in the web since the browser handles ordered list numbering. However when using this library in React Native, we have to render the list number ourselves, so the React Native library assumes that the `index` refers to the index of the item in the list. (see https://github.com/portabletext/react-native-portabletext/blob/main/src/components/list.tsx#L26)

## The solution

Here's a screenshot illustrating the change: the text in bold shows the value of `index` before and after the change.

| Before     | After     |
| ---------- | --------- |
| <img width="289" alt="Screenshot 2023-04-20 at 11 56 09" src="https://user-images.githubusercontent.com/6534400/233347927-d4c9dd85-34b5-4874-a2b6-6fb3d54b8780.png">   |  <img width="281" alt="Screenshot 2023-04-20 at 11 56 34" src="https://user-images.githubusercontent.com/6534400/233347918-2cc70706-fb2f-45e9-8288-d6cb312179bc.png">  

I was unable to write a test for this following existing testing patterns, because all the existing tests are snapshots of rendered HTML, which is completely unaffected by this change on the web.
