### PR TITLE
chore: format with prettier v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ Migrating from [@sanity/block-content-to-react](https://www.npmjs.com/package/@s
 
 ## Table of contents
 
-* [Installation](#installation)
-* [Basic usage](#basic-usage)
-* [Styling](#styling-the-output)
-* [Customizing components](#customizing-components)
-* [Available components](#available-components)
-  * [types](#types)
-  * [marks](#marks)
-  * [block](#block)
-  * [list](#list)
-  * [listItem](#listItem)
-  * [hardBreak](#hardBreak)
-  * [unknown components](#unknownMark)
-* [Disable warnings / Handling unknown types](#disabling-warnings--handling-unknown-types)
-* [Rendering Plain Text](#rendering-plain-text)
-* [Typing Portable Text](#typing-portable-text)
+- [Installation](#installation)
+- [Basic usage](#basic-usage)
+- [Styling](#styling-the-output)
+- [Customizing components](#customizing-components)
+- [Available components](#available-components)
+  - [types](#types)
+  - [marks](#marks)
+  - [block](#block)
+  - [list](#list)
+  - [listItem](#listItem)
+  - [hardBreak](#hardBreak)
+  - [unknown components](#unknownMark)
+- [Disable warnings / Handling unknown types](#disabling-warnings--handling-unknown-types)
+- [Rendering Plain Text](#rendering-plain-text)
+- [Typing Portable Text](#typing-portable-text)
 
 ## Installation
 
@@ -343,14 +343,13 @@ interface PortableTextBlock<
   M extends PortableTextMarkDefinition = PortableTextMarkDefinition,
   C extends TypedObject = ArbitraryTypedObject | PortableTextSpan,
   S extends string = PortableTextBlockStyle,
-  L extends string = PortableTextListItemType
+  L extends string = PortableTextListItemType,
 > {}
 ```
 
 Create your own, narrowed Portable text type:
 
 ```ts
-
 import {PortableTextBlock, PortableTextMarkDefinition, PortableTextSpan} from '@portabletext/types'
 
 // MARKS
@@ -398,7 +397,6 @@ interface MyCustomBlock {
   _type: 'myCustomBlock'
   // ...other fields
 }
-
 
 // TYPE FOR PORTABLE TEXT FIELD ITEMS
 type PortableTextFieldType = CustomPortableTextBlock | MyCustomBlock

--- a/demo/demo.tsx
+++ b/demo/demo.tsx
@@ -59,5 +59,5 @@ render(
       <Demo />
     </ThemeProvider>
   </React.StrictMode>,
-  document.getElementById('demo-root')
+  document.getElementById('demo-root'),
 )

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/src/components/merge.ts
+++ b/src/components/merge.ts
@@ -2,7 +2,7 @@ import type {PortableTextReactComponents, PortableTextComponents} from '../types
 
 export function mergeComponents(
   parent: PortableTextReactComponents,
-  overrides: PortableTextComponents
+  overrides: PortableTextComponents,
 ): PortableTextReactComponents {
   const {block, list, listItem, marks, types, ...rest} = overrides
   // @todo figure out how to not `as ...` these
@@ -20,7 +20,7 @@ export function mergeComponents(
 function mergeDeeply(
   parent: PortableTextReactComponents,
   overrides: PortableTextComponents,
-  key: 'block' | 'list' | 'listItem' | 'marks' | 'types'
+  key: 'block' | 'list' | 'listItem' | 'marks' | 'types',
 ): PortableTextReactComponents[typeof key] {
   const override = overrides[key]
   const parentVal = parent[key]

--- a/src/react-portable-text.tsx
+++ b/src/react-portable-text.tsx
@@ -1,9 +1,5 @@
-import React, {ReactNode, useMemo} from 'react'
-import {
-  LIST_NEST_MODE_HTML,
-  ToolkitNestedPortableTextSpan,
-  ToolkitTextNode,
-} from '@portabletext/toolkit'
+import React, {type ReactNode, useMemo} from 'react'
+import type {ToolkitNestedPortableTextSpan, ToolkitTextNode} from '@portabletext/toolkit'
 import type {
   MissingComponentHandler,
   NodeRenderer,
@@ -14,6 +10,7 @@ import type {
   SerializedBlock,
 } from './types'
 import {
+  LIST_NEST_MODE_HTML,
   isPortableTextBlock,
   isPortableTextListItemBlock,
   isPortableTextToolkitList,
@@ -59,10 +56,10 @@ export function PortableText<B extends TypedObject = PortableTextBlock>({
 
   const renderNode = useMemo(
     () => getNodeRenderer(components, handleMissingComponent),
-    [components, handleMissingComponent]
+    [components, handleMissingComponent],
   )
   const rendered = nested.map((node, index) =>
-    renderNode({node: node, index, isInline: false, renderNode})
+    renderNode({node: node, index, isInline: false, renderNode}),
   )
 
   return <>{rendered}</>
@@ -70,7 +67,7 @@ export function PortableText<B extends TypedObject = PortableTextBlock>({
 
 const getNodeRenderer = (
   components: PortableTextReactComponents,
-  handleMissingComponent: MissingComponentHandler
+  handleMissingComponent: MissingComponentHandler,
 ): NodeRenderer => {
   function renderNode<N extends TypedObject>(options: Serializable<N>): ReactNode {
     const {node, index, isInline} = options
@@ -111,7 +108,7 @@ const getNodeRenderer = (
   function renderListItem(
     node: PortableTextListItemBlock<PortableTextMarkDefinition, PortableTextSpan>,
     index: number,
-    key: string
+    key: string,
   ) {
     const tree = serializeBlock({node, index, isInline: false, renderNode})
     const renderer = components.listItem
@@ -147,7 +144,7 @@ const getNodeRenderer = (
         index: childIndex,
         isInline: false,
         renderNode,
-      })
+      }),
     )
 
     const component = components.list
@@ -170,7 +167,7 @@ const getNodeRenderer = (
     const {markDef, markType, markKey} = node
     const Span = components.marks[markType] || components.unknownMark
     const children = node.children.map((child, childIndex) =>
-      renderNode({node: child, index: childIndex, isInline: true, renderNode})
+      renderNode({node: child, index: childIndex, isInline: true, renderNode}),
     )
 
     if (Span === components.unknownMark) {
@@ -251,7 +248,7 @@ function serializeBlock(options: Serializable<PortableTextBlock>): SerializedBlo
   const {node, index, isInline, renderNode} = options
   const tree = buildMarksTree(node)
   const children = tree.map((child, i) =>
-    renderNode({node: child, isInline: true, index: i, renderNode})
+    renderNode({node: child, isInline: true, index: i, renderNode}),
   )
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ import type {
  * @template B Types that can appear in the array of blocks
  */
 export interface PortableTextProps<
-  B extends TypedObject = PortableTextBlock | ArbitraryTypedObject
+  B extends TypedObject = PortableTextBlock | ArbitraryTypedObject,
 > {
   /**
    * One or more blocks to render
@@ -287,7 +287,7 @@ export type NodeType = 'block' | 'mark' | 'blockStyle' | 'listStyle' | 'listItem
 
 export type MissingComponentHandler = (
   message: string,
-  options: {type: string; nodeType: NodeType}
+  options: {type: string; nodeType: NodeType},
 ) => void
 
 export interface Serializable<T> {

--- a/test/components.test.tsx
+++ b/test/components.test.tsx
@@ -27,7 +27,7 @@ tap.test('can override unknown mark component', (t) => {
   })
   t.same(
     result,
-    '<p><span class="unknown">Unknown (unknown-deco): simple</span><span class="unknown">Unknown (unknown-mark): advanced</span></p>'
+    '<p><span class="unknown">Unknown (unknown-deco): simple</span><span class="unknown">Unknown (unknown-mark): advanced</span></p>',
   )
   t.end()
 })

--- a/test/portable-text.test.tsx
+++ b/test/portable-text.test.tsx
@@ -235,7 +235,7 @@ tap.test('can render custom list item styles with provided list style component'
   })
   t.same(
     result,
-    '<ul class="list-squared"><li>Square 1</li><li>Square 2<ul><li>Dat disc</li></ul></li><li>Square 3</li></ul>'
+    '<ul class="list-squared"><li>Square 1</li><li>Square 2<ul><li>Dat disc</li></ul></li><li>Square 3</li></ul>',
   )
   t.end()
 })
@@ -252,7 +252,7 @@ tap.test('can render custom list item styles with provided list style component'
   })
   t.same(
     result,
-    '<ul><li class="item-squared">Square 1</li><li class="item-squared">Square 2<ul><li>Dat disc</li></ul></li><li class="item-squared">Square 3</li></ul>'
+    '<ul><li class="item-squared">Square 1</li><li class="item-squared">Square 2<ul><li>Dat disc</li></ul></li><li class="item-squared">Square 3</li></ul>',
   )
   t.end()
 })
@@ -265,7 +265,7 @@ tap.test('warns on missing list style component', (t) => {
   })
   t.same(
     result,
-    '<ul><li>Square 1</li><li>Square 2<ul><li>Dat disc</li></ul></li><li>Square 3</li></ul>'
+    '<ul><li>Square 1</li><li>Square 2<ul><li>Dat disc</li></ul></li><li>Square 3</li></ul>',
   )
   t.end()
 })
@@ -387,7 +387,7 @@ tap.test('can register custom `missing component` handler', (t) => {
   render({value: input, onMissingComponent})
   t.same(
     warning,
-    '[@portabletext/react] Unknown mark type "abc", specify a component for it in the `components.marks` prop'
+    '[@portabletext/react] Unknown mark type "abc", specify a component for it in the `components.marks` prop',
   )
   t.end()
 })


### PR DESCRIPTION
With the upgrade to prettier v3 comes trailing commas set to `all`. Also ran the formatter on the whole codebase, including markdown.

Tidied up a few imports, as well.