### PR TITLE
feat: add `react-compiler` export condition

### DIFF
--- a/package.config.ts
+++ b/package.config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import {defineConfig} from '@sanity/pkg-utils'
 import {visualizer} from 'rollup-plugin-visualizer'
 
@@ -23,8 +24,25 @@ export default defineConfig({
   },
 
   babel: {
-    plugins: ['@babel/plugin-proposal-object-rest-spread'],
+    plugins: ['@babel/plugin-transform-object-rest-spread'],
   },
 
   tsconfig: 'tsconfig.dist.json',
+
+  reactCompilerOptions: {
+    logger: {
+      logEvent(filename, event) {
+        if (event.kind === 'CompileError') {
+          console.group(`[${filename}] ${event.kind}`)
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const {reason, description, severity, loc, suggestions} = event.detail as any
+          console.error(`[${severity}] ${reason}`)
+          console.log(`${filename}:${loc.start?.line}:${loc.start?.column} ${description}`)
+          console.log(suggestions)
+
+          console.groupEnd()
+        }
+      },
+    },
+  },
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@portabletext/react",
-  "version": "3.1.0",
+  "version": "3.1.0-canary.2",
   "description": "Render Portable Text with React",
   "keywords": [
     "portable-text"
@@ -20,6 +20,10 @@
   "exports": {
     ".": {
       "source": "./src/index.ts",
+      "react-compiler": {
+        "source": "./src/index.ts",
+        "default": "./dist/index.compiled.js"
+      },
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "default": "./dist/index.js"
@@ -97,7 +101,7 @@
     "@portabletext/types": "^2.0.13"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+    "@babel/plugin-transform-object-rest-spread": "^7.24.7",
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
     "@sanity/pkg-utils": "^6.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,9 @@ importers:
         specifier: ^2.0.13
         version: 2.0.13
     devDependencies:
-      '@babel/plugin-proposal-object-rest-spread':
-        specifier: ^7.20.7
-        version: 7.20.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-object-rest-spread':
+        specifier: ^7.24.7
+        version: 7.24.7(@babel/core@7.24.7)
       '@commitlint/cli':
         specifier: ^19.3.0
         version: 19.3.0(@types/node@20.12.4)(typescript@5.4.5)
@@ -256,13 +256,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/plugin-proposal-object-rest-spread@7.20.7':
-    resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-proposal-private-methods@7.18.6':
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
@@ -293,8 +286,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-parameters@7.24.1':
-    resolution: {integrity: sha512-8Jl6V24g+Uw5OGPeWNKrKqXPDw2YDjLc53ojwfMcKwlEoETKU9rU0mHUtcg9JntWI/QYzGAXNWEcVHZ+fR+XXg==}
+  '@babel/plugin-transform-object-rest-spread@7.24.7':
+    resolution: {integrity: sha512-4QrHAr0aXQCEFni2q4DqKLD31n2DL+RxcwnNjDFkSG0eNQ/xCavnRkfCUjsyqGC2OviNJvZOF/mQqZBw7i2C5Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-parameters@7.24.7':
+    resolution: {integrity: sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3718,15 +3717,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.7
 
-  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.24.7)':
-    dependencies:
-      '@babel/compat-data': 7.24.7
-      '@babel/core': 7.24.7
-      '@babel/helper-compilation-targets': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.24.7)
-
   '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
@@ -3759,7 +3749,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.24.1(@babel/core@7.24.7)':
+  '@babel/plugin-transform-object-rest-spread@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
+
+  '@babel/plugin-transform-parameters@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7


### PR DESCRIPTION
The React Compiler were struggling to understand the flow of `<PortableText>`: https://github.com/portabletext/react-portabletext/blob/11fbc8a8c698c103d28936523affda2398b70d27/src/react-portable-text.tsx#L42-L67
And it got different results for its `useMemo` deps arrays that were used to memo `renderNode`, and thus opted out from optimizing it.

Here's a diff of what happens if you add `react-compiler` without refactoring anything, and with the changes in this PR: https://npmdiff.dev/%40portabletext%2Freact/3.0.18-canary.0/3.1.0-canary.2/package/dist/index.compiled.js/

What I like about the implementation on `main` is that if the `components` and `onMissingComponent` props were stable, then a changing `value` prop didn't result in `getNodeRenderer` and `mergeComponents` being called more than once. I wanted to preserve this behaviour, while also changing the code so that the compiler understands it and can auto memoize it further.

By splitting the work into two separate components we preserve the previous memoization, while adding a few new benefits:
- Since `<PortableText>` is now wrapped in `memo` it can opt-out of looping a possibly very deep recursive tree of `renderNode` if parent components rerender but the props given to `<PortableText>` haven't changed.
- It's easier to track why portable text components rerender, as react profiling will tell you that "PortableTextRenderer rerendered because prop 'renderNode' changed" instead of "PortableText rerendered because hook 2 changed"