### PR TITLE
feat: fully support sanity typegen

### DIFF
--- a/.changeset/typegen-component-inference.md
+++ b/.changeset/typegen-component-inference.md
@@ -1,0 +1,256 @@
+---
+"@portabletext/react": minor
+---
+
+# TypeGen-aware Portable Text components
+
+`<PortableText>` now infers the shape of every component handler from the `value` prop. When you pass a value typed by [Sanity TypeGen](https://www.sanity.io/docs/apis-and-sdks/sanity-typegen), `components.types`, `components.marks`, `components.block`, `components.list`, and `components.listItem` all receive precise `value` props for the exact content the query returned.
+
+Three new utility types ship with this feature:
+
+- `InferComponents<T>` - same inference as the inline `components` prop, for hoisting components out of JSX.
+- `InferStrictComponents<T>` - strict variant that requires a handler for every inferred custom type, mark, block style, and list style, and rejects handlers that aren't in the schema (and therefore not visible to TypeGen).
+- `InferValue<T>` - derives a Portable Text array value type from any TypeGen query result type, useful for re-usable wrapper components.
+
+## Schema
+
+Every example below assumes the same `sanity.config.ts`:
+
+```ts
+// sanity.config.ts
+import {defineArrayMember, defineConfig, defineField, defineType} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  projectId: 'abc123',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'post',
+        type: 'document',
+        fields: [
+          defineField({name: 'title', type: 'string'}),
+          defineField({
+            name: 'content',
+            type: 'array',
+            of: [
+              defineArrayMember({type: 'block'}),
+              defineArrayMember({
+                type: 'image',
+                options: {hotspot: true},
+                fields: [defineField({name: 'alt', type: 'string'})],
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  },
+})
+```
+
+## Before: hand-typing handlers
+
+Previously, every handler had to be typed by hand to mirror the generated query shape:
+
+```tsx
+// app/[slug]/page.tsx
+import {createClient} from '@sanity/client'
+import {createImageUrlBuilder} from '@sanity/image-url'
+import {PortableText} from '@portabletext/react'
+import {defineQuery} from 'groq'
+
+const client = createClient({
+  projectId: 'abc123',
+  dataset: 'production',
+  useCdn: true,
+  apiVersion: '2026-05-04',
+})
+const builder = createImageUrlBuilder(client)
+
+export default async function Page({slug}: {slug: string}) {
+  const query = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title,content}`)
+  const data = await client.fetch(query, {slug})
+
+  if (!data) return notFound()
+
+  return (
+    <article>
+      <h1>{data.title}</h1>
+      <PortableText
+        components={{
+          types: {
+            image: ({
+              value,
+            }: {
+              value: {
+                asset?: {
+                  _ref: string
+                  _type: 'reference'
+                  _weak?: boolean
+                }
+                hotspot?: {
+                  _type: 'sanity.imageHotspot'
+                  x?: number
+                  y?: number
+                  height?: number
+                  width?: number
+                }
+                crop?: {
+                  _type: 'sanity.imageCrop'
+                  top?: number
+                  bottom?: number
+                  left?: number
+                  right?: number
+                }
+                alt?: string
+                _type: 'image'
+                _key: string
+              }
+            }) => <img src={builder.image(value).url()} alt={value.alt || ''} />,
+          },
+        }}
+        value={data.content}
+      />
+    </article>
+  )
+}
+```
+
+## After: automatic inference
+
+Now the same handler is fully typed straight from `data.content`:
+
+```tsx
+// app/[slug]/page.tsx
+import {createClient} from '@sanity/client'
+import {createImageUrlBuilder} from '@sanity/image-url'
+import {PortableText} from '@portabletext/react'
+import {defineQuery} from 'groq'
+
+const client = createClient({
+  projectId: 'abc123',
+  dataset: 'production',
+  useCdn: true,
+  apiVersion: '2026-05-04',
+})
+const builder = createImageUrlBuilder(client)
+
+export default async function Page({slug}: {slug: string}) {
+  const query = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title,content}`)
+  const data = await client.fetch(query, {slug})
+
+  if (!data) return notFound()
+
+  return (
+    <article>
+      <h1>{data.title}</h1>
+      <PortableText
+        components={{
+          types: {
+            // value is fully typed from the query result, no annotation needed
+            image: ({value}) => (
+              <img src={builder.image(value).url()} alt={value.alt || ''} />
+            ),
+          },
+        }}
+        value={data.content}
+      />
+    </article>
+  )
+}
+```
+
+## `InferComponents`: hoisting components without losing inference
+
+Move the `components` map out of JSX and keep the same inferred handler types:
+
+```tsx
+// app/[slug]/page.tsx
+import {createClient} from '@sanity/client'
+import {createImageUrlBuilder} from '@sanity/image-url'
+import {PortableText, type InferComponents} from '@portabletext/react'
+import {defineQuery} from 'groq'
+
+const client = createClient({
+  projectId: 'abc123',
+  dataset: 'production',
+  useCdn: true,
+  apiVersion: '2026-05-04',
+})
+const builder = createImageUrlBuilder(client)
+
+export default async function Page({slug}: {slug: string}) {
+  const query = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title,content}`)
+  const data = await client.fetch(query, {slug})
+
+  if (!data) return notFound()
+
+  const components = {
+    types: {
+      image: ({value}) => <img src={builder.image(value).url()} alt={value.alt || ''} />,
+    },
+  } satisfies InferComponents<typeof data.content>
+
+  return (
+    <article>
+      <h1>{data.title}</h1>
+      <PortableText components={components} value={data.content} />
+    </article>
+  )
+}
+```
+
+## `InferStrictComponents` + `InferValue`: a strict, re-usable wrapper
+
+`InferValue<SanityQueries[keyof SanityQueries]>` collects every Portable Text item shape from every registered TypeGen query into an array value type, and `InferStrictComponents` requires a handler for each of them. Together they're perfect for a single `CustomPortableText` you reuse across the app:
+
+```tsx
+// app/[slug]/page.tsx
+import {createClient, type SanityQueries} from '@sanity/client'
+import {createImageUrlBuilder} from '@sanity/image-url'
+import {
+  PortableText,
+  type InferStrictComponents,
+  type InferValue,
+} from '@portabletext/react'
+import {defineQuery} from 'groq'
+
+const client = createClient({
+  projectId: 'abc123',
+  dataset: 'production',
+  useCdn: true,
+  apiVersion: '2026-05-04',
+})
+const builder = createImageUrlBuilder(client)
+
+// Array value type for every Portable Text item shape across all registered queries.
+type PortableTextValue = InferValue<SanityQueries[keyof SanityQueries]>
+
+function CustomPortableText({value}: {value: PortableTextValue}) {
+  const components = {
+    types: {
+      image: ({value}) => <img src={builder.image(value).url()} alt={value.alt || ''} />,
+    },
+  } satisfies InferStrictComponents<PortableTextValue>
+  //   ^ TypeScript errors when the schema gains a custom type, mark, or list
+  //     style without a matching handler defined here
+
+  return <PortableText components={components} value={value} />
+}
+
+export default async function Page({slug}: {slug: string}) {
+  const query = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title,content}`)
+  const data = await client.fetch(query, {slug})
+
+  if (!data) return notFound()
+
+  return (
+    <article>
+      <h1>{data.title}</h1>
+      {Array.isArray(data.content) && <CustomPortableText value={data.content} />}
+    </article>
+  )
+}
+```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Migrating from [@sanity/block-content-to-react](https://www.npmjs.com/package/@s
   - [unknown components](#unknownMark)
 - [Disable warnings / Handling unknown types](#disabling-warnings--handling-unknown-types)
 - [Rendering Plain Text](#rendering-plain-text)
-- [Typing Portable Text](#typing-portable-text)
+- [Sanity TypeGen Compatibility](#sanity-typegen-compatibility)
+  - [A re-usable `CustomPortableText` component](#a-re-usable-customportabletext-component)
+  - [Choosing what to feed `InferValue<T>`](#choosing-what-to-feed-infervaluet)
+  - [`InferComponents` vs `InferStrictComponents`](#infercomponents-vs-inferstrictcomponents)
+- [Manually Typing Portable Text](#manually-typing-portable-text)
 
 ## Installation
 
@@ -112,7 +116,7 @@ const SampleImageComponent = ({value, isInline}) => {
         .fit('max')
         .auto('format')
         .url()}
-      alt={value.alt || ' '}
+      alt={value.alt || ''}
       loading="lazy"
       style={{
         // Display alongside text if image appears inside a block text span
@@ -150,7 +154,7 @@ The component also receives a `children` prop that should (usually) be returned 
 // `components` object you'll pass to PortableText w/ optional TS definition
 import {PortableTextComponents} from '@portabletext/react'
 
-const components: PortableTextComponents = {
+const components = {
   marks: {
     // Ex. 1: custom renderer for the em / italics decorator
     em: ({children}) => <em className="text-gray-600 font-semibold">{children}</em>,
@@ -165,7 +169,7 @@ const components: PortableTextComponents = {
       )
     },
   },
-}
+} satisfies PortableTextComponents
 ```
 
 ### `block`
@@ -176,7 +180,7 @@ An object of React components that renders portable text blocks with different `
 import {PortableText, PortableTextReactComponents} from '@portabletext/react'
 
 // `components` object you'll pass to PortableText
-const components: Partial<PortableTextReactComponents> = {
+const components = {
   block: {
     // Ex. 1: customizing common block types
     normal: ({children}) => <p className="text-sm">{children}</p>,
@@ -188,7 +192,7 @@ const components: Partial<PortableTextReactComponents> = {
       <h2 className="text-lg text-primary text-purple-700">{children}</h2>
     ),
   },
-}
+} satisfies Partial<PortableTextReactComponents>
 ```
 
 The `block` object can also be set to a single React component, which would handle block styles of _any_ type.
@@ -314,16 +318,178 @@ const LinkableHeader = ({children, value}) => {
   return <h2 id={slug}>{children}</h2>
 }
 
-const components: PortableTextComponents = {
+const components = {
   block: {
     h2: LinkableHeader,
   },
+} satisfies PortableTextComponents
+```
+
+## Sanity TypeGen Compatibility
+
+When you use [Sanity TypeGen](https://www.sanity.io/docs/apis-and-sdks/sanity-typegen), `@portabletext/react` infers everything for you - which custom types, marks, block styles, and list styles your handlers receive, and what shape their `value` props have - directly from your queries. No manual generics or hand-written type unions needed.
+
+The library exposes three utility types to make this ergonomic:
+
+- `InferValue<T>` - derives a Portable Text array value type from any TypeGen query result type.
+- `InferComponents<T>` - forgiving component map type, mirrors the inline `components` prop inference.
+- `InferStrictComponents<T>` - strict component map type, requires inferred handlers and rejects unknown ones.
+
+### A re-usable `CustomPortableText` component
+
+This is the recommended pattern for a single Portable Text renderer that you reuse across your app. `InferValue<SanityQueries[keyof SanityQueries]>` collects every Portable Text item shape returned by every registered TypeGen query into an array value type, and `InferStrictComponents` forces you to define a handler for each of them.
+
+```tsx
+import type { SanityQueries} from '@sanity/client'
+import {createImageUrlBuilder} from '@sanity/image-url'
+import {
+  PortableText,
+  type InferStrictComponents,
+  type InferValue,
+} from '@portabletext/react'
+
+const builder = createImageUrlBuilder(...)
+
+// Array value type for every Portable Text item shape across all registered queries.
+type PortableTextValue = InferValue<SanityQueries[keyof SanityQueries]>
+
+export function CustomPortableText({value}: {value: PortableTextValue}) {
+  const components = {
+    types: {
+      // `value` is fully typed from the inferred image variant.
+      image: ({value}) => <img src={builder.image(value).url()} alt={value.alt || ''} />,
+    },
+    // Add `types`, `marks`, `block`, `list` etc. handlers as your schema requires.
+  } satisfies InferStrictComponents<PortableTextValue>
+  //   ^ TypeScript errors when the schema gains a custom type, block, mark, or list
+  //     style without a matching handler defined here.
+
+  return <PortableText components={components} value={value} />
 }
 ```
 
-## Typing Portable Text
+You can drop this component in anywhere a TypeGen-typed Portable Text array shows up:
 
-Portable Text data can be typed using the `@portabletext/types` package.
+```tsx
+import {createClient} from '@sanity/client'
+import {defineQuery} from 'groq'
+
+const client = createClient(...)
+
+
+export default async function Page({slug}: {slug: string}) {
+  const postQuery = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title,content}`)
+  const data = await client.fetch(postQuery, {slug})
+
+  if (!data) return notFound()
+
+  return (
+    <article>
+      <h1>{data.title}</h1>
+      {Array.isArray(data.content) && <CustomPortableText value={data.content} />}
+    </article>
+  )
+}
+```
+
+### Choosing what to feed `InferValue<T>`
+
+`InferValue<T>` is meant for re-usable wrapper components that accept Portable Text via a `value` prop. You feed it a TypeGen-generated _query_ result type (or union of them) so the component covers every shape it might be asked to render. It returns the array value type directly, so `type PortableTextValue = InferValue<...>` can be used as the `value` prop type without adding `[]` yourself.
+
+> Feed `InferValue` query result types, not Sanity schema types. Schema types describe how content is **stored** in Sanity, not how it's **queried**. For example, an `inlineAuthor` value with an `author` reference is stored as `{_type: 'inlineAuthor', author: {_ref: string, _type: 'reference'}}`, but a query that follows the reference with `author->` will return `{_type: 'inlineAuthor', author: {_id: string, _type: 'author', ...}}`. Always type from query results.
+
+There are three common strategies:
+
+**Preferred: every registered query**
+
+```tsx
+import {type SanityQueries} from '@sanity/client'
+
+type PortableTextValue = InferValue<SanityQueries[keyof SanityQueries]>
+```
+
+This auto-updates as you add or remove queries, so you don't have to come back and adjust the prop type later. Requires `overloadClientMethods` in `sanity.cli.ts#typegen` (on by default).
+
+**Fallback: specific named queries**
+
+If `SanityQueries[keyof SanityQueries]` produces too large a union and slows down type-checking, narrow it to the specific query results that contain Portable Text fields:
+
+```tsx
+import type {AuthorQueryResult, PostQueryResult} from './sanity.types'
+
+type PortableTextValue = InferValue<AuthorQueryResult | PostQueryResult>
+```
+
+You'll have to keep this union in sync as you add or change queries; that trade-off is the cost of skipping the wide one.
+
+**Alternative: a scoped mock query**
+
+You can define a focused GROQ query inside `CustomPortableText` purely for type generation. TypeGen registers it in `SanityQueries` like any other, but you only feed _its_ result type into `InferValue`, keeping the union tight:
+
+```tsx
+import {type SanityQueries} from '@sanity/client'
+import {defineQuery} from 'groq'
+
+const mockQuery = defineQuery(`*[_type in ["author", "category", "post"]]{
+  _type == "author" => {bio},
+  _type == "category" => {description},
+  _type == "post" => {content},
+}`)
+
+function CustomPortableText({value}: {value: InferValue<SanityQueries[typeof mockQuery]>}) {
+  // ...
+}
+```
+
+Use this when `SanityQueries[keyof SanityQueries]` is too slow but you don't want to maintain a hand-written union of named query results either.
+
+**Don't combine** the mock query with `SanityQueries[keyof SanityQueries]` - the mock query gets added to `SanityQueries` and bloats the union you're trying to avoid. Pick one strategy or the other.
+
+### `InferComponents` vs `InferStrictComponents`
+
+Both utilities derive component handler types from a value type. They differ in how strict they are.
+
+**`InferComponents<T>`** - forgiving. Mirrors the same inference behavior as inlining `components` directly on `<PortableText>`:
+
+- All handlers are optional.
+- Extra handlers for types not present in `T` are allowed (they fall back to `any`).
+- Best for: incremental migration, partial coverage, schemas that change often.
+
+```tsx
+import {PortableText, type InferComponents} from '@portabletext/react'
+
+const components = {
+  types: {
+    image: ({value}) => <img src={builder.image(value).url()} alt={value.alt || ''} />,
+    // Optional: legacy types not in the current schema are allowed.
+  },
+} satisfies InferComponents<typeof data.content>
+```
+
+**`InferStrictComponents<T>`** - strict. Treats your schema as the contract:
+
+- Custom types, marks, block styles, and list styles inferred from `T` are **required**.
+- Handlers for keys that aren't inferred from `T` are **rejected**.
+- Default handlers (`em`, `strong`, `link`, `normal`, `h1`-`h6`, `bullet`, `number`, etc.) remain optional - the library renders them by default.
+- Best for: production-grade renderers where missing or stale handlers should fail TypeScript.
+
+```tsx
+import {PortableText, type InferStrictComponents} from '@portabletext/react'
+
+const components = {
+  types: {
+    image: ({value}) => <img src={builder.image(value).url()} alt={value.alt || ''} />,
+    // Omit `image` and TypeScript errors.
+    // Add `legacyEmbed` and TypeScript errors.
+  },
+} satisfies InferStrictComponents<typeof data.content>
+```
+
+Pick `InferComponents` when you want flexibility, and `InferStrictComponents` when you want TypeScript to scream the moment your schema and your renderer go out of sync.
+
+## Manually Typing Portable Text
+
+If you're not using Sanity TypeGen, Portable Text data can be typed using the [`@portabletext/types`](https://www.npmjs.com/package/@portabletext/types) package.
 
 ### Basic usage
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./src/index.ts",
@@ -46,7 +44,8 @@
     "release": "changeset publish",
     "start": "pnpm dev",
     "test": "vitest",
-    "type-check": "tsc --noEmit"
+    "typegen": "(cd test/typegen && sanity schema extract && sanity typegen generate)",
+    "type-check": "tsc --noEmit -p tsconfig.dist.json"
   },
   "dependencies": {
     "@portabletext/toolkit": "^5.0.2",
@@ -56,6 +55,7 @@
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.31.0",
     "@sanity/client": "^7.22.0",
+    "@sanity/image-url": "^2.1.1",
     "@sanity/tsconfig": "^2.1.0",
     "@sanity/tsdown-config": "^0.6.1",
     "@sanity/ui": "^3.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@sanity/client':
         specifier: ^7.22.0
         version: 7.22.0
+      '@sanity/image-url':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@sanity/tsconfig':
         specifier: ^2.1.0
         version: 2.1.0

--- a/src/components/defaults.tsx
+++ b/src/components/defaults.tsx
@@ -1,7 +1,10 @@
-import type {PortableTextBlockStyle} from '@portabletext/types'
 import type {JSX} from 'react'
 
-import type {PortableTextBlockComponent, PortableTextReactComponents} from '../types'
+import type {
+  DefaultPortableTextBlockStyle,
+  PortableTextBlockComponent,
+  PortableTextReactComponents,
+} from '../types'
 import {DefaultListItem, defaultLists} from './list'
 import {defaultMarks} from './marks'
 import {
@@ -14,19 +17,17 @@ import {
 
 export const DefaultHardBreak = (): JSX.Element => <br />
 
-export const defaultBlockStyles: Record<
-  PortableTextBlockStyle,
-  PortableTextBlockComponent | undefined
-> = {
-  normal: ({children}) => <p>{children}</p>,
-  blockquote: ({children}) => <blockquote>{children}</blockquote>,
-  h1: ({children}) => <h1>{children}</h1>,
-  h2: ({children}) => <h2>{children}</h2>,
-  h3: ({children}) => <h3>{children}</h3>,
-  h4: ({children}) => <h4>{children}</h4>,
-  h5: ({children}) => <h5>{children}</h5>,
-  h6: ({children}) => <h6>{children}</h6>,
-}
+export const defaultBlockStyles: Record<DefaultPortableTextBlockStyle, PortableTextBlockComponent> =
+  {
+    normal: ({children}) => <p>{children}</p>,
+    blockquote: ({children}) => <blockquote>{children}</blockquote>,
+    h1: ({children}) => <h1>{children}</h1>,
+    h2: ({children}) => <h2>{children}</h2>,
+    h3: ({children}) => <h3>{children}</h3>,
+    h4: ({children}) => <h4>{children}</h4>,
+    h5: ({children}) => <h5>{children}</h5>,
+    h6: ({children}) => <h6>{children}</h6>,
+  }
 
 export const defaultComponents: PortableTextReactComponents = {
   types: {},

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -1,6 +1,10 @@
-import type {PortableTextListComponent, PortableTextListItemComponent} from '../types'
+import type {
+  DefaultPortableTextListItem,
+  PortableTextListComponent,
+  PortableTextListItemComponent,
+} from '../types'
 
-export const defaultLists: Record<'number' | 'bullet', PortableTextListComponent> = {
+export const defaultLists: Record<DefaultPortableTextListItem, PortableTextListComponent> = {
   number: ({children}) => <ol>{children}</ol>,
   bullet: ({children}) => <ul>{children}</ul>,
 }

--- a/src/components/marks.tsx
+++ b/src/components/marks.tsx
@@ -1,6 +1,6 @@
 import type {TypedObject} from '@portabletext/types'
 
-import type {PortableTextMarkComponent} from '../types'
+import type {DefaultPortableTextMark, PortableTextMarkComponent} from '../types'
 
 interface DefaultLink extends TypedObject {
   _type: 'link'
@@ -13,7 +13,7 @@ const link: PortableTextMarkComponent<DefaultLink> = ({children, value}) => (
 
 const underlineStyle = {textDecoration: 'underline'}
 
-export const defaultMarks: Record<string, PortableTextMarkComponent | undefined> = {
+export const defaultMarks: Record<DefaultPortableTextMark, PortableTextMarkComponent> = {
   em: ({children}) => <em>{children}</em>,
   strong: ({children}) => <strong>{children}</strong>,
   code: ({children}) => <code>{children}</code>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export interface PortableTextProps<
   /**
    * React components to use for rendering
    */
-  components?: Partial<PortableTextReactComponents>
+  components?: PortableTextComponents<B>
 
   /**
    * Function to call when encountering unknown unknown types, eg blocks, marks,
@@ -88,17 +88,482 @@ type LooseRecord<K extends string, V> = Record<string, V> & {
   [P in K]?: V // autocompleted keys
 }
 
+// Pull literal `_type` names out of TypeGen unions so component maps can offer
+// precise keys like `image`, `quote`, `link`, etc.
+type TypeName<T> = T extends {_type: infer Name} ? (Name extends string ? Name : never) : never
+
+// `@portabletext/types` exposes defaults as literal unions plus `(string & {})`
+// for custom values. Keep only the literal default members.
+type BuiltInPortableTextString<T> = T extends string ? (string extends T ? never : T) : never
+
+type CustomPortableTextType<B extends TypedObject> = Exclude<B, {_type: 'block'}>
+
+type CustomPortableTextTypeName<B extends TypedObject> = TypeName<CustomPortableTextType<B>>
+
+type PortableTextBlockType<B extends TypedObject> = Extract<B, {_type: 'block'}>
+
+export type DefaultPortableTextBlockStyle = BuiltInPortableTextString<PortableTextBlockStyle>
+
+// Extract block style literals from the value union, for example `normal | h2`.
+type PortableTextBlockStyleName<B extends TypedObject> =
+  PortableTextBlockType<B> extends {style?: infer Style}
+    ? NonNullable<Style> extends string
+      ? NonNullable<Style>
+      : never
+    : never
+
+type CustomPortableTextBlockStyleName<B extends TypedObject> = Exclude<
+  PortableTextBlockStyleName<B>,
+  DefaultPortableTextBlockStyle
+>
+
+// Contextualize each style handler with the matching block style. The `style`
+// property remains optional because Portable Text blocks may omit it at runtime.
+type PortableTextBlockForStyle<B extends TypedObject, Style extends string> =
+  PortableTextBlockType<B> extends infer Block
+    ? Block extends TypedObject
+      ? Omit<Block, 'style'> & {style?: Extract<Block extends {style?: infer S} ? S : never, Style>}
+      : never
+    : never
+
+type PortableTextBlockComponentFor<B extends TypedObject> =
+  PortableTextBlockType<B> extends never
+    ? PortableTextBlockComponent
+    : PortableTextComponent<PortableTextBlockType<B>>
+
+type PortableTextBlockComponents<B extends TypedObject> =
+  string extends PortableTextBlockStyleName<B>
+    ? LooseRecord<PortableTextBlockStyle, PortableTextBlockComponent | undefined>
+    : PortableTextBlockStyleName<B> extends never
+      ? LooseRecord<PortableTextBlockStyle, PortableTextBlockComponent | undefined>
+      : // Known styles get precise value props; unknown extra styles stay allowed
+        // and fall back to `any` for the forgiving default behavior.
+        Record<string, PortableTextComponent<any> | undefined> & {
+          [Style in PortableTextBlockStyleName<B>]?: PortableTextComponent<
+            PortableTextBlockForStyle<B, Style>
+          >
+        }
+
+// Extract list item style literals from the value union, for example
+// `checklist | steps`.
+type PortableTextListItemName<B extends TypedObject> =
+  PortableTextBlockType<B> extends {listItem?: infer ListItem}
+    ? NonNullable<ListItem> extends string
+      ? NonNullable<ListItem>
+      : never
+    : never
+
+export type DefaultPortableTextListItem = BuiltInPortableTextString<PortableTextListItemType>
+
+type CustomPortableTextListItemName<B extends TypedObject> = Exclude<
+  PortableTextListItemName<B>,
+  DefaultPortableTextListItem
+>
+
+// Lists are virtual toolkit nodes created from list item blocks. Keep the
+// toolkit shape, but narrow `listItem` to the specific style being rendered.
+type PortableTextListForItem<ListItem extends string> = ReactPortableTextList extends infer List
+  ? List extends ReactPortableTextList
+    ? Omit<List, 'listItem'> & {listItem: ListItem}
+    : never
+  : never
+
+// List item renderers receive the original block, but only after the toolkit
+// has identified it as a list item, so `listItem` is required for the handler.
+type PortableTextBlockForListItem<B extends TypedObject, ListItem extends string> =
+  PortableTextBlockType<B> extends infer Block
+    ? Block extends TypedObject
+      ? Omit<Block, 'listItem'> & {
+          listItem: Extract<Block extends {listItem?: infer Item} ? Item : never, ListItem>
+        }
+      : never
+    : never
+
+type PortableTextListComponentFor<B extends TypedObject> =
+  PortableTextListItemName<B> extends never
+    ? PortableTextListComponent
+    : PortableTextComponent<PortableTextListForItem<PortableTextListItemName<B>>>
+
+type PortableTextListItemComponentFor<B extends TypedObject> =
+  PortableTextListItemName<B> extends never
+    ? PortableTextListItemComponent
+    : PortableTextComponent<PortableTextBlockForListItem<B, PortableTextListItemName<B>>>
+
+type PortableTextListComponents<B extends TypedObject> =
+  string extends PortableTextListItemName<B>
+    ? LooseRecord<PortableTextListItemType, PortableTextListComponent | undefined>
+    : PortableTextListItemName<B> extends never
+      ? Record<string, PortableTextComponent<any> | undefined>
+      : // Known list styles get precise virtual list props; unknown extra list
+        // styles stay allowed and fall back to `any`.
+        Record<string, PortableTextComponent<any> | undefined> & {
+          [ListItem in PortableTextListItemName<B>]?: PortableTextComponent<
+            PortableTextListForItem<ListItem>
+          >
+        }
+
+type PortableTextListItemComponents<B extends TypedObject> =
+  string extends PortableTextListItemName<B>
+    ? LooseRecord<PortableTextListItemType, PortableTextListItemComponent | undefined>
+    : PortableTextListItemName<B> extends never
+      ? Record<string, PortableTextComponent<any> | undefined>
+      : // Known list item styles get precise block props; unknown extra list item
+        // styles stay allowed and fall back to `any`.
+        Record<string, PortableTextComponent<any> | undefined> & {
+          [ListItem in PortableTextListItemName<B>]?: PortableTextComponent<
+            PortableTextBlockForListItem<B, ListItem>
+          >
+        }
+
+// Extract annotation mark definitions from block `markDefs`.
+type PortableTextMarkType<B extends TypedObject> =
+  PortableTextBlockType<B> extends {markDefs?: infer MarkDefs}
+    ? NonNullable<MarkDefs> extends readonly (infer MarkDef)[]
+      ? Extract<MarkDef, TypedObject>
+      : never
+    : never
+
+type PortableTextMarkTypeName<B extends TypedObject> = TypeName<PortableTextMarkType<B>>
+
+// Unlike block styles and list items, `@portabletext/types` does not expose a
+// default mark-name union. Keep this union aligned with `defaultMarks`, which
+// is typed as `Record<DefaultPortableTextMark, ...>` to enforce coverage.
+export type DefaultPortableTextMark =
+  | 'em'
+  | 'strong'
+  | 'code'
+  | 'underline'
+  | 'strike-through'
+  | 'link'
+
+type CustomPortableTextMarkTypeName<B extends TypedObject> = Exclude<
+  PortableTextMarkTypeName<B>,
+  DefaultPortableTextMark
+>
+
+type PortableTextMarkComponents<B extends TypedObject> =
+  string extends PortableTextMarkTypeName<B>
+    ? Record<string, PortableTextMarkComponent | undefined>
+    : PortableTextMarkTypeName<B> extends never
+      ? Record<string, PortableTextMarkComponent | undefined>
+      : // Known marks get precise `value` props; unknown extra marks stay allowed
+        // and fall back to `any`.
+        Record<string, PortableTextMarkComponent | undefined> & {
+          [Type in PortableTextMarkTypeName<B>]?: PortableTextMarkComponent<
+            Extract<PortableTextMarkType<B>, {_type: Type}>
+          >
+        }
+
+type PortableTextTypeComponents<B extends TypedObject> =
+  string extends CustomPortableTextTypeName<B>
+    ? Record<string, PortableTextTypeComponent | undefined>
+    : CustomPortableTextTypeName<B> extends never
+      ? Record<string, PortableTextTypeComponent | undefined>
+      : // Known custom object types get precise `value` props; unknown extra types
+        // stay allowed and fall back to `any`.
+        Record<string, PortableTextTypeComponent | undefined> & {
+          [Type in CustomPortableTextTypeName<B>]?: PortableTextTypeComponent<
+            Extract<CustomPortableTextType<B>, {_type: Type}>
+          >
+        }
+
+type PortableTextValueItem<T> = Extract<
+  NonNullable<T> extends readonly (infer B)[] ? B : NonNullable<T>,
+  TypedObject
+>
+
+type PortableTextArrayItem<T> =
+  NonNullable<T> extends readonly (infer Item)[]
+    ? Extract<NonNullable<Item>, {_type: 'block'}> extends never
+      ? never
+      : Extract<NonNullable<Item>, TypedObject>
+    : never
+
+type InferPortableTextTypedObject<T> = T extends unknown
+  ? PortableTextArrayItem<T> extends never
+    ? NonNullable<T> extends readonly (infer Item)[]
+      ? InferPortableTextTypedObject<Item>
+      : NonNullable<T> extends object
+        ? {
+            [Key in keyof NonNullable<T>]: InferPortableTextTypedObject<NonNullable<T>[Key]>
+          }[keyof NonNullable<T>]
+        : never
+    : PortableTextArrayItem<T>
+  : never
+
+type StrictPortableTextTypeComponents<B extends TypedObject> =
+  string extends CustomPortableTextTypeName<B>
+    ? Record<string, PortableTextTypeComponent | undefined>
+    : CustomPortableTextTypeName<B> extends never
+      ? Record<string, never>
+      : {
+          [Type in CustomPortableTextTypeName<B>]-?: PortableTextTypeComponent<
+            Extract<CustomPortableTextType<B>, {_type: Type}>
+          >
+        }
+
+type StrictPortableTextTypeComponentOverrides<B extends TypedObject> =
+  CustomPortableTextTypeName<B> extends never
+    ? {types?: StrictPortableTextTypeComponents<B>}
+    : {types: StrictPortableTextTypeComponents<B>}
+
+type StrictPortableTextMarkComponents<B extends TypedObject> =
+  string extends PortableTextMarkTypeName<B>
+    ? Record<string, PortableTextMarkComponent | undefined>
+    : PortableTextMarkTypeName<B> extends never
+      ? Record<string, never>
+      : {
+          [Type in CustomPortableTextMarkTypeName<B>]-?: PortableTextMarkComponent<
+            Extract<PortableTextMarkType<B>, {_type: Type}>
+          >
+        } & {
+          [Type in Extract<
+            DefaultPortableTextMark,
+            PortableTextMarkTypeName<B>
+          >]?: PortableTextMarkComponent<Extract<PortableTextMarkType<B>, {_type: Type}>>
+        }
+
+type StrictPortableTextMarkComponentOverrides<B extends TypedObject> =
+  CustomPortableTextMarkTypeName<B> extends never
+    ? {marks?: StrictPortableTextMarkComponents<B>}
+    : {marks: StrictPortableTextMarkComponents<B>}
+
+type StrictPortableTextBlockComponents<B extends TypedObject> =
+  string extends PortableTextBlockStyleName<B>
+    ? LooseRecord<PortableTextBlockStyle, PortableTextBlockComponent | undefined>
+    : PortableTextBlockStyleName<B> extends never
+      ? Record<string, never>
+      : {
+          [Style in CustomPortableTextBlockStyleName<B>]-?: PortableTextComponent<
+            PortableTextBlockForStyle<B, Style>
+          >
+        } & {
+          [Style in Extract<
+            DefaultPortableTextBlockStyle,
+            PortableTextBlockStyleName<B>
+          >]?: PortableTextComponent<PortableTextBlockForStyle<B, Style>>
+        }
+
+type StrictPortableTextBlockComponentOverrides<B extends TypedObject> =
+  CustomPortableTextBlockStyleName<B> extends never
+    ? {block?: StrictPortableTextBlockComponents<B> | PortableTextBlockComponentFor<B>}
+    : {block: StrictPortableTextBlockComponents<B> | PortableTextBlockComponentFor<B>}
+
+type StrictPortableTextListComponents<B extends TypedObject> =
+  string extends PortableTextListItemName<B>
+    ? LooseRecord<PortableTextListItemType, PortableTextListComponent | undefined>
+    : PortableTextListItemName<B> extends never
+      ? Record<string, never>
+      : {
+          [ListItem in CustomPortableTextListItemName<B>]-?: PortableTextComponent<
+            PortableTextListForItem<ListItem>
+          >
+        } & {
+          [ListItem in Extract<
+            DefaultPortableTextListItem,
+            PortableTextListItemName<B>
+          >]?: PortableTextComponent<PortableTextListForItem<ListItem>>
+        }
+
+type StrictPortableTextListComponentOverrides<B extends TypedObject> =
+  CustomPortableTextListItemName<B> extends never
+    ? {list?: StrictPortableTextListComponents<B> | PortableTextListComponentFor<B>}
+    : {list: StrictPortableTextListComponents<B> | PortableTextListComponentFor<B>}
+
+type StrictPortableTextListItemComponents<B extends TypedObject> =
+  string extends PortableTextListItemName<B>
+    ? LooseRecord<PortableTextListItemType, PortableTextListItemComponent | undefined>
+    : PortableTextListItemName<B> extends never
+      ? Record<string, never>
+      : {
+          [ListItem in PortableTextListItemName<B>]-?: PortableTextComponent<
+            PortableTextBlockForListItem<B, ListItem>
+          >
+        }
+
+type StrictPortableTextListItemComponentOverrides<B extends TypedObject> = {
+  listItem?: StrictPortableTextListItemComponents<B> | PortableTextListItemComponentFor<B>
+}
+
 /**
  * Object defining the different React components to use for rendering various aspects
  * of Portable Text and user-provided types, where only the overrides needs to be provided.
  */
-export type PortableTextComponents = Partial<PortableTextReactComponents>
+export type PortableTextComponents<B extends TypedObject = any> = Partial<
+  PortableTextReactComponents<B>
+>
+
+/**
+ * Infer Portable Text components from a value type. This matches the inference
+ * behavior of the `components` prop on `<PortableText>`.
+ *
+ * This is useful when working with
+ * [Sanity TypeGen](https://www.sanity.io/docs/apis-and-sdks/sanity-typegen),
+ * where `defineQuery()` and `client.fetch()` can infer the shape of Portable
+ * Text fields.
+ *
+ * @example
+ * ```tsx
+ * import {PortableText, type InferComponents} from '@portabletext/react'
+ * import {createClient} from '@sanity/client'
+ * import {defineQuery} from 'groq'
+ *
+ * const client = createClient(...)
+ *
+ * export default async function Page({slug}: {slug: string}) {
+ *   const query = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title,content}`)
+ *   const data = await client.fetch(query, {slug})
+ *   const components = {
+ *     block: {
+ *       // custom types are autocompleted and fully typed
+ *     },
+ *   } satisfies InferComponents<typeof data.content>
+ *
+ *   return (
+ *     <>
+ *       ...
+ *       {Array.isArray(data?.content) && <PortableText components={components} value={data.content} />}
+ *     </>
+ *   )
+ * }
+ * ```
+ */
+export type InferComponents<T> = PortableTextComponents<PortableTextValueItem<T>>
+
+/**
+ * Infer the Portable Text array value type from
+ * [Sanity TypeGen](https://www.sanity.io/docs/apis-and-sdks/sanity-typegen)
+ * generated types.
+ *
+ * Useful when building a re-usable wrapper component that only takes `value`
+ * as an input prop and sets up `components` internally. Pass a TypeGen-
+ * generated query result type that contains Portable Text fields - such as
+ * an individual query result like `PostQueryResult`, or the `SanityQueries`
+ * interface from `@sanity/client` - and `InferValue<T>` returns an array type
+ * containing every Portable Text item shape it can find.
+ *
+ * Always feed `InferValue<T>` query result types, not Sanity schema types.
+ * Schema types describe how content is stored, which can differ from how it
+ * is queried (e.g. references resolved with `->`).
+ *
+ * @example
+ * ```tsx
+ * // Re-usable component typed against specific query results.
+ * import {PortableText, type InferValue} from '@portabletext/react'
+ * import {createImageUrlBuilder} from '@sanity/image-url'
+ *
+ * import type {AuthorQueryResult, PostQueryResult} from './sanity.types'
+ *
+ * type PortableTextValue = InferValue<PostQueryResult | AuthorQueryResult>
+ *
+ * export function CustomPortableText(props: {value: PortableTextValue}) {
+ *   const builder = createImageUrlBuilder()
+ *
+ *   return (
+ *     <PortableText
+ *       components={{
+ *         types: {
+ *           image: ({value}) => {
+ *             const width = 1920
+ *             const height = 1080
+ *             return (
+ *               <img
+ *                 src={builder
+ *                   .image(value)
+ *                   .width(width)
+ *                   .height(height)
+ *                   .fit('max')
+ *                   .auto('format')
+ *                   .url()}
+ *                 alt={value.alt || ''}
+ *                 loading="lazy"
+ *                 height={height}
+ *                 width={width}
+ *               />
+ *             )
+ *           },
+ *         },
+ *       }}
+ *       value={props.value}
+ *     />
+ *   )
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Strictly typed re-usable component that handles every Portable Text shape
+ * // returned by registered queries. Relies on `overloadClientMethods` being
+ * // enabled in `sanity.cli.ts#typegen` (the default).
+ * import {type SanityQueries} from '@sanity/client'
+ * import {createImageUrlBuilder} from '@sanity/image-url'
+ * import {
+ *   PortableText,
+ *   type InferStrictComponents,
+ *   type InferValue,
+ * } from '@portabletext/react'
+ *
+ * type PortableTextValue = InferValue<SanityQueries[keyof SanityQueries]>
+ *
+ * export function CustomPortableText(props: {value: PortableTextValue}) {
+ *   const builder = createImageUrlBuilder()
+ *
+ *   const components = {
+ *     types: {
+ *       image: ({value}) => {
+ *         const width = 1920
+ *         const height = 1080
+ *         return (
+ *           <img
+ *             src={builder
+ *               .image(value)
+ *               .width(width)
+ *               .height(height)
+ *               .fit('max')
+ *               .auto('format')
+ *               .url()}
+ *             alt={value.alt || ''}
+ *             loading="lazy"
+ *             height={height}
+ *             width={width}
+ *           />
+ *         )
+ *       },
+ *     },
+ *   } satisfies InferStrictComponents<PortableTextValue>
+ *
+ *   return <PortableText components={components} value={props.value} />
+ * }
+ * ```
+ */
+export type InferValue<T> = Exclude<InferPortableTextTypedObject<T>, undefined>[]
+
+/**
+ * Infer Portable Text components from a value type, requiring handlers for all
+ * custom object types and disallowing extra custom object type handlers.
+ *
+ * This is used the same way as {@link InferComponents}, but serves a different
+ * purpose: `InferComponents` is forgiving and mirrors the inline
+ * `<PortableText components={...} />` experience, allowing custom handlers to
+ * be omitted and allowing handlers for types that do not exist in, or could not
+ * be inferred from, the value type. `InferStrictComponents` is strict: it
+ * requires inferred custom handlers and rejects unknown ones.
+ */
+export type InferStrictComponents<T> = Omit<
+  PortableTextComponents<PortableTextValueItem<T>>,
+  'types' | 'marks' | 'block' | 'list' | 'listItem'
+> &
+  StrictPortableTextTypeComponentOverrides<PortableTextValueItem<T>> &
+  StrictPortableTextMarkComponentOverrides<PortableTextValueItem<T>> &
+  StrictPortableTextBlockComponentOverrides<PortableTextValueItem<T>> &
+  StrictPortableTextListComponentOverrides<PortableTextValueItem<T>> &
+  StrictPortableTextListItemComponentOverrides<PortableTextValueItem<T>>
 
 /**
  * Object definining the different React components to use for rendering various aspects
  * of Portable Text and user-provided types.
  */
-export interface PortableTextReactComponents {
+export interface PortableTextReactComponents<B extends TypedObject = any> {
   /**
    * Object of React components that renders different types of objects that might appear
    * both as part of the blocks array, or as inline objects _inside_ of a block,
@@ -109,7 +574,7 @@ export interface PortableTextReactComponents {
    * The object has the shape `{typeName: ReactComponent}`, where `typeName` is the value set
    * in individual `_type` attributes.
    */
-  types: Record<string, PortableTextTypeComponent | undefined>
+  types: PortableTextTypeComponents<B>
 
   /**
    * Object of React components that renders different types of marks that might appear in spans.
@@ -117,7 +582,7 @@ export interface PortableTextReactComponents {
    * The object has the shape `{markName: ReactComponent}`, where `markName` is the value set
    * in individual `_type` attributes, values being stored in the parent blocks `markDefs`.
    */
-  marks: Record<string, PortableTextMarkComponent | undefined>
+  marks: PortableTextMarkComponents<B>
 
   /**
    * Object of React components that renders blocks with different `style` properties.
@@ -127,9 +592,7 @@ export interface PortableTextReactComponents {
    *
    * Can also be set to a single React component, which would handle block styles of _any_ type.
    */
-  block:
-    | LooseRecord<PortableTextBlockStyle, PortableTextBlockComponent | undefined>
-    | PortableTextBlockComponent
+  block: PortableTextBlockComponents<B> | PortableTextBlockComponentFor<B>
 
   /**
    * Object of React components used to render lists of different types (bulleted vs numbered,
@@ -141,9 +604,7 @@ export interface PortableTextReactComponents {
    *
    * Can also be set to a single React component, which would handle lists of _any_ type.
    */
-  list:
-    | LooseRecord<PortableTextListItemType, PortableTextListComponent | undefined>
-    | PortableTextListComponent
+  list: PortableTextListComponents<B> | PortableTextListComponentFor<B>
 
   /**
    * Object of React components used to render different list item styles.
@@ -153,9 +614,7 @@ export interface PortableTextReactComponents {
    *
    * Can also be set to a single React component, which would handle list items of _any_ type.
    */
-  listItem:
-    | LooseRecord<PortableTextListItemType, PortableTextListItemComponent | undefined>
-    | PortableTextListItemComponent
+  listItem: PortableTextListItemComponents<B> | PortableTextListItemComponentFor<B>
 
   /**
    * Component to use for rendering "hard breaks", eg `\n` inside of text spans

--- a/test/typegen/sanity.config.ts
+++ b/test/typegen/sanity.config.ts
@@ -34,6 +34,7 @@ const post = defineType({
             {title: 'H2', value: 'h2'},
             {title: 'H3', value: 'h3'},
             {title: 'Quote', value: 'blockquote'},
+            {title: 'Lead', value: 'lead'},
           ],
           marks: {
             decorators: [
@@ -56,8 +57,24 @@ const post = defineType({
                   }),
                 ],
               },
+              {
+                name: 'glossaryTerm',
+                type: 'object',
+                title: 'Glossary Term',
+                fields: [
+                  defineField({
+                    name: 'term',
+                    type: 'string',
+                    title: 'Term',
+                  }),
+                ],
+              },
             ],
           },
+          lists: [
+            {title: 'Checklist', value: 'checklist'},
+            {title: 'Steps', value: 'steps'},
+          ],
         }),
         defineArrayMember({
           name: 'image',
@@ -172,12 +189,53 @@ const author = defineType({
   ],
 })
 
+const category = defineType({
+  name: 'category',
+  title: 'Category',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'block',
+          styles: [{title: 'Normal', value: 'normal'}],
+          marks: {
+            decorators: [{title: 'Emphasis', value: 'em'}],
+            annotations: [],
+          },
+          lists: [],
+        }),
+        defineArrayMember({
+          name: 'featuredPost',
+          title: 'Featured Post',
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'post',
+              type: 'reference',
+              to: [{type: 'post'}],
+            }),
+          ],
+        }),
+      ],
+    }),
+  ],
+})
+
 export default defineConfig({
   name: 'default',
   title: 'Typegen Test',
   projectId: 'test-project',
   dataset: 'production',
   schema: {
-    types: [post, author],
+    types: [post, author, category],
   },
 })

--- a/test/typegen/sanity.types.ts
+++ b/test/typegen/sanity.types.ts
@@ -15,6 +15,43 @@
 export declare const internalGroqTypeReferenceTo: unique symbol;
 
 // Source: schema.json
+export type PostReference = {
+  _ref: string;
+  _type: "reference";
+  _weak?: boolean;
+  [internalGroqTypeReferenceTo]?: "post";
+};
+
+export type Category = {
+  _id: string;
+  _type: "category";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  title?: string;
+  description?: Array<
+    | {
+        children?: Array<{
+          marks?: Array<string>;
+          text?: string;
+          _type: "span";
+          _key: string;
+        }>;
+        style?: "normal";
+        listItem?: never;
+        markDefs?: null;
+        level?: number;
+        _type: "block";
+        _key: string;
+      }
+    | {
+        post?: PostReference;
+        _type: "featuredPost";
+        _key: string;
+      }
+  >;
+};
+
 export type AuthorReference = {
   _ref: string;
   _type: "reference";
@@ -46,13 +83,20 @@ export type Post = {
           _type: "span";
           _key: string;
         }>;
-        style?: "normal" | "h2" | "h3" | "blockquote";
-        listItem?: "bullet" | "number";
-        markDefs?: Array<{
-          href?: string;
-          _type: "link";
-          _key: string;
-        }>;
+        style?: "normal" | "h2" | "h3" | "blockquote" | "lead";
+        listItem?: "checklist" | "steps";
+        markDefs?: Array<
+          | {
+              href?: string;
+              _type: "link";
+              _key: string;
+            }
+          | {
+              term?: string;
+              _type: "glossaryTerm";
+              _key: string;
+            }
+        >;
         level?: number;
         _type: "block";
         _key: string;
@@ -237,6 +281,8 @@ export type Geopoint = {
 };
 
 export type AllSanitySchemaTypes =
+  | PostReference
+  | Category
   | AuthorReference
   | SanityImageAssetReference
   | Post
@@ -253,7 +299,7 @@ export type AllSanitySchemaTypes =
   | SanityImageAsset
   | Geopoint;
 
-// Source: typegen.test-d.ts
+// Source: typegen.test-d.tsx
 // Variable: postQuery
 // Query: *[_type == "post" && slug.current == $slug][0]{title,author->{name,avatar},content}
 export type PostQueryResult = {
@@ -276,13 +322,20 @@ export type PostQueryResult = {
           _type: "span";
           _key: string;
         }>;
-        style?: "blockquote" | "h2" | "h3" | "normal";
-        listItem?: "bullet" | "number";
-        markDefs?: Array<{
-          href?: string;
-          _type: "link";
-          _key: string;
-        }>;
+        style?: "blockquote" | "h2" | "h3" | "lead" | "normal";
+        listItem?: "checklist" | "steps";
+        markDefs?: Array<
+          | {
+              term?: string;
+              _type: "glossaryTerm";
+              _key: string;
+            }
+          | {
+              href?: string;
+              _type: "link";
+              _key: string;
+            }
+        >;
         level?: number;
         _type: "block";
         _key: string;
@@ -313,7 +366,7 @@ export type PostQueryResult = {
   > | null;
 } | null;
 
-// Source: typegen.test-d.ts
+// Source: typegen.test-d.tsx
 // Variable: authorQuery
 // Query: *[_type == "author" && _id == $id][0]{name,avatar,bio}
 export type AuthorQueryResult = {
@@ -345,11 +398,156 @@ export type AuthorQueryResult = {
   }> | null;
 } | null;
 
+// Source: typegen.test-d.tsx
+// Variable: categoryQuery
+// Query: *[_type == "category" && _id == $id][0]{title,description[]{    ...,    _type == "featuredPost" => {      ...,      post->{title,author->{name,"avatar":avatar.asset->url},"slug":slug.current}    }  }}
+export type CategoryQueryResult = {
+  title: string | null;
+  description: Array<
+    | {
+        children?: Array<{
+          marks?: Array<string>;
+          text?: string;
+          _type: "span";
+          _key: string;
+        }>;
+        style?: "normal";
+        listItem?: never;
+        markDefs?: null;
+        level?: number;
+        _type: "block";
+        _key: string;
+      }
+    | {
+        post: {
+          title: string | null;
+          author: {
+            name: string | null;
+            avatar: string | null;
+          } | null;
+          slug: string | null;
+        } | null;
+        _type: "featuredPost";
+        _key: string;
+      }
+  > | null;
+} | null;
+
+// Source: typegen.test-d.tsx
+// Variable: mockQuery
+// Query: *[_type in ["author", "category", "post"]]{      _type == "author" => {bio},      _type == "category" => {        description[]{          ...,          _type == "featuredPost" => {            ...,            post->{title,author->{name,"avatar":avatar.asset->url},"slug":slug.current}          }        }      },      _type == "post" => {content},    }
+export type MockQueryResult = Array<
+  | {
+      bio: Array<{
+        children?: Array<{
+          marks?: Array<string>;
+          text?: string;
+          _type: "span";
+          _key: string;
+        }>;
+        style?: "normal";
+        listItem?: never;
+        markDefs?: Array<{
+          href?: string;
+          _type: "link";
+          _key: string;
+        }>;
+        level?: number;
+        _type: "block";
+        _key: string;
+      }> | null;
+    }
+  | {
+      content: Array<
+        | {
+            children?: Array<{
+              marks?: Array<string>;
+              text?: string;
+              _type: "span";
+              _key: string;
+            }>;
+            style?: "blockquote" | "h2" | "h3" | "lead" | "normal";
+            listItem?: "checklist" | "steps";
+            markDefs?: Array<
+              | {
+                  term?: string;
+                  _type: "glossaryTerm";
+                  _key: string;
+                }
+              | {
+                  href?: string;
+                  _type: "link";
+                  _key: string;
+                }
+            >;
+            level?: number;
+            _type: "block";
+            _key: string;
+          }
+        | {
+            language?: string;
+            code?: string;
+            filename?: string;
+            _type: "code";
+            _key: string;
+          }
+        | {
+            asset?: SanityImageAssetReference;
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            alt?: string;
+            caption?: string;
+            _type: "image";
+            _key: string;
+          }
+        | {
+            text?: string;
+            attribution?: string;
+            _type: "quote";
+            _key: string;
+          }
+      > | null;
+    }
+  | {
+      description: Array<
+        | {
+            children?: Array<{
+              marks?: Array<string>;
+              text?: string;
+              _type: "span";
+              _key: string;
+            }>;
+            style?: "normal";
+            listItem?: never;
+            markDefs?: null;
+            level?: number;
+            _type: "block";
+            _key: string;
+          }
+        | {
+            post: {
+              title: string | null;
+              author: {
+                name: string | null;
+                avatar: string | null;
+              } | null;
+              slug: string | null;
+            } | null;
+            _type: "featuredPost";
+            _key: string;
+          }
+      > | null;
+    }
+>;
+
 // Query TypeMap
 import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
     '*[_type == "post" && slug.current == $slug][0]{title,author->{name,avatar},content}': PostQueryResult;
     '*[_type == "author" && _id == $id][0]{name,avatar,bio}': AuthorQueryResult;
+    '*[_type == "category" && _id == $id][0]{title,description[]{\n    ...,\n    _type == "featuredPost" => {\n      ...,\n      post->{title,author->{name,"avatar":avatar.asset->url},"slug":slug.current}\n    }\n  }}': CategoryQueryResult;
+    '*[_type in ["author", "category", "post"]]{\n      _type == "author" => {bio},\n      _type == "category" => {\n        description[]{\n          ...,\n          _type == "featuredPost" => {\n            ...,\n            post->{title,author->{name,"avatar":avatar.asset->url},"slug":slug.current}\n          }\n        }\n      },\n      _type == "post" => {content},\n    }': MockQueryResult;
   }
 }

--- a/test/typegen/schema.json
+++ b/test/typegen/schema.json
@@ -1,6 +1,228 @@
 [
   {
     "type": "type",
+    "name": "post.reference",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_ref": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "reference"
+          }
+        },
+        "_weak": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        }
+      },
+      "dereferencesTo": "post"
+    }
+  },
+  {
+    "name": "category",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "category"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "description": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "union",
+            "of": [
+              {
+                "type": "object",
+                "attributes": {
+                  "children": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "array",
+                      "of": {
+                        "type": "object",
+                        "attributes": {
+                          "marks": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "array",
+                              "of": {
+                                "type": "string"
+                              }
+                            },
+                            "optional": true
+                          },
+                          "text": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string"
+                            },
+                            "optional": true
+                          },
+                          "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string",
+                              "value": "span"
+                            }
+                          }
+                        },
+                        "rest": {
+                          "type": "object",
+                          "attributes": {
+                            "_key": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "optional": true
+                  },
+                  "style": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "union",
+                      "of": [
+                        {
+                          "type": "string",
+                          "value": "normal"
+                        }
+                      ]
+                    },
+                    "optional": true
+                  },
+                  "listItem": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "union",
+                      "of": []
+                    },
+                    "optional": true
+                  },
+                  "markDefs": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "null"
+                    },
+                    "optional": true
+                  },
+                  "level": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "number"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "block"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "object",
+                  "attributes": {
+                    "_key": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "post": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "post.reference"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "featuredPost"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "object",
+                  "attributes": {
+                    "_key": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "type": "type",
     "name": "author.reference",
     "value": {
       "type": "object",
@@ -194,6 +416,10 @@
                         {
                           "type": "string",
                           "value": "blockquote"
+                        },
+                        {
+                          "type": "string",
+                          "value": "lead"
                         }
                       ]
                     },
@@ -206,11 +432,11 @@
                       "of": [
                         {
                           "type": "string",
-                          "value": "bullet"
+                          "value": "checklist"
                         },
                         {
                           "type": "string",
-                          "value": "number"
+                          "value": "steps"
                         }
                       ]
                     },
@@ -221,34 +447,69 @@
                     "value": {
                       "type": "array",
                       "of": {
-                        "type": "object",
-                        "attributes": {
-                          "href": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string"
+                        "type": "union",
+                        "of": [
+                          {
+                            "type": "object",
+                            "attributes": {
+                              "href": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string"
+                                },
+                                "optional": true
+                              },
+                              "_type": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string",
+                                  "value": "link"
+                                }
+                              }
                             },
-                            "optional": true
-                          },
-                          "_type": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                              "value": "link"
+                            "rest": {
+                              "type": "object",
+                              "attributes": {
+                                "_key": {
+                                  "type": "objectAttribute",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
                             }
-                          }
-                        },
-                        "rest": {
-                          "type": "object",
-                          "attributes": {
-                            "_key": {
-                              "type": "objectAttribute",
-                              "value": {
-                                "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "attributes": {
+                              "term": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string"
+                                },
+                                "optional": true
+                              },
+                              "_type": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string",
+                                  "value": "glossaryTerm"
+                                }
+                              }
+                            },
+                            "rest": {
+                              "type": "object",
+                              "attributes": {
+                                "_key": {
+                                  "type": "objectAttribute",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
                           }
-                        }
+                        ]
                       }
                     },
                     "optional": true

--- a/test/typegen/typegen.test-d.tsx
+++ b/test/typegen/typegen.test-d.tsx
@@ -1,4 +1,12 @@
-import {PortableText} from '@portabletext/react'
+import {
+  type InferComponents,
+  type InferStrictComponents,
+  type InferValue,
+  PortableText,
+  type PortableTextComponentProps,
+  type PortableTextMarkComponentProps,
+  type PortableTextTypeComponentProps,
+} from '@portabletext/react'
 /**
  * Type-level tests for @portabletext/react with Sanity TypeGen generated types.
  *
@@ -7,20 +15,18 @@ import {PortableText} from '@portabletext/react'
  * - What already works (e.g., non-null TypeGen arrays are assignable to `value`)
  * - What we want to support (documented via placeholder tests and comments)
  *
- * The actual type improvements (making `value` accept `null`, exposing
- * `InferPortableTextComponents` and `InferStrictPortableTextComponents`) will
- * be implemented in a follow-up PR, at which point these tests will be extended
- * with assertions that currently would fail.
- *
  * The goal is:
  * 1. `value` prop should accept TypeGen query results directly (including `null` and optional values)
  * 2. `components` should infer allowed custom types, marks, and styles from the `value` type
- * 3. Expose `InferPortableTextComponents<T>` - requires all custom types but allows extras
- * 4. Expose `InferStrictPortableTextComponents<T>` - strict mode, no extras allowed
+ * 3. Expose `InferComponents<T>` - same inference behavior as the components prop
+ * 4. Expose `InferStrictComponents<T>` - strict mode, no extras allowed
  */
-import {createClient} from '@sanity/client'
+import {createClient, type SanityQueries} from '@sanity/client'
+import {createImageUrlBuilder} from '@sanity/image-url'
 import {defineQuery} from 'groq'
-import {assertType, describe, expectTypeOf, test} from 'vitest'
+import {describe, expectTypeOf, test} from 'vitest'
+
+import type {AllSanitySchemaTypes} from './sanity.types'
 
 const client = createClient({
   projectId: 'test',
@@ -28,6 +34,7 @@ const client = createClient({
   useCdn: true,
   apiVersion: '2024-01-01',
 })
+const builder = createImageUrlBuilder(client)
 
 // do not explicitly type the return of `fetchPost` or `fetchAuthor` as we rely on inference and client overloading
 async function fetchPost(slug: string) {
@@ -42,86 +49,362 @@ async function fetchAuthor(id: string) {
   return await client.fetch(authorQuery, {id})
 }
 
+async function fetchCategory(id: string) {
+  const categoryQuery = defineQuery(`*[_type == "category" && _id == $id][0]{title,description[]{
+    ...,
+    _type == "featuredPost" => {
+      ...,
+      post->{title,author->{name,"avatar":avatar.asset->url},"slug":slug.current}
+    }
+  }}`)
+  return await client.fetch(categoryQuery, {id})
+}
+
 describe('TypeGen value prop compatibility', () => {
-  test('PostQueryResult.content should be assignable to PortableText value (currently fails)', async () => {
+  test('PostQueryResult.content should be assignable to PortableText value', async () => {
     const post = await fetchPost('foo')
 
-    // The `content` field from TypeGen is `Array<...> | null`
-    // PortableText's `value` prop accepts `null` (renders nothing) and the TypeGen array directly
-
-    ;<PortableText value={post!.content} />
+    ;<PortableText value={post?.content} />
   })
 
-  test('AuthorQueryResult.bio should be assignable to value prop (currently fails)', async () => {
+  test('AuthorQueryResult.bio should be assignable to value prop', async () => {
     const author = await fetchAuthor('123')
 
-    ;<PortableText value={author!.bio} />
-  })
-
-  test('Individual block types have _type and _key as required by TypedObject', async () => {
-    const post = await fetchPost('foo')
-    type PostData = NonNullable<typeof post>
-    type PostContent = NonNullable<PostData['content']>
-    type PostContentBlock = PostContent[number]
-
-    // TypeGen generates `_type: "block"` which is a literal string - good!
-    // But `_key` is required in TypeGen output, which should satisfy TypedObject
-    expectTypeOf<PostContentBlock>().toHaveProperty('_type')
-    expectTypeOf<PostContentBlock>().toHaveProperty('_key')
+    ;<PortableText value={author?.bio} />
   })
 })
 
-describe('TypeGen components inference for post content', () => {
-  test('should be able to extract custom block types from content union', async () => {
+describe('PortableText component with TypeGen types', () => {
+  test('should infer custom types in components.types from post content', async () => {
     const post = await fetchPost('foo')
+    const content = post?.content
     type PostData = NonNullable<typeof post>
     type PostContent = NonNullable<PostData['content']>
     type PostContentBlock = PostContent[number]
-
-    // From the TypeGen output, the custom types in post content are: image, quote, code
     type CustomTypes = Exclude<PostContentBlock, {_type: 'block'}>
-    type CustomTypeNames = CustomTypes['_type']
 
-    // Verify the union contains the expected types
-    expectTypeOf<'image'>().toMatchTypeOf<CustomTypeNames>()
-    expectTypeOf<'quote'>().toMatchTypeOf<CustomTypeNames>()
-    expectTypeOf<'code'>().toMatchTypeOf<CustomTypeNames>()
+    // When passing TypeGen content to PortableText, the `components.types`
+    // should autocomplete with 'image', 'quote', 'code' from the content union.
+    ;<PortableText
+      value={content}
+      components={{
+        types: {
+          image: ({value, isInline}) => {
+            expectTypeOf(value).toEqualTypeOf<
+              PortableTextTypeComponentProps<Extract<CustomTypes, {_type: 'image'}>>['value']
+            >()
+            const width = 1920
+            const height = 1080
+            return (
+              <img
+                src={builder
+                  .image(value)
+                  .width(width)
+                  .height(height)
+                  .fit('max')
+                  .auto('format')
+                  .url()}
+                alt={value.alt || ''}
+                loading="lazy"
+                height={height}
+                width={width}
+                style={{
+                  // Display alongside text if image appears inside a block text span
+                  display: isInline ? 'inline-block' : 'block',
+                }}
+              />
+            )
+          },
+          quote: ({value}) => {
+            expectTypeOf(value).toEqualTypeOf<
+              PortableTextTypeComponentProps<Extract<CustomTypes, {_type: 'quote'}>>['value']
+            >()
+            return (
+              <figure>
+                <blockquote>
+                  <p>{value.text}</p>
+                </blockquote>
+                <figcaption>{value.attribution}</figcaption>
+              </figure>
+            )
+          },
+          code: ({value}) => {
+            expectTypeOf(value).toEqualTypeOf<
+              PortableTextTypeComponentProps<Extract<CustomTypes, {_type: 'code'}>>['value']
+            >()
+            return (
+              <pre>
+                <code>{value.code}</code>
+              </pre>
+            )
+          },
+        },
+      }}
+    />
   })
 
-  test('should be able to extract mark types from block markDefs', async () => {
+  test('should infer annotation marks in components.marks from post content', async () => {
     const post = await fetchPost('foo')
+    const content = post?.content
     type PostData = NonNullable<typeof post>
     type PostContent = NonNullable<PostData['content']>
     type PostContentBlock = PostContent[number]
-
     type BlockType = Extract<PostContentBlock, {_type: 'block'}>
     type MarkDefs = NonNullable<BlockType['markDefs']>
     type MarkType = MarkDefs[number]
 
-    // The only annotation mark in post content is 'link'
-    expectTypeOf<MarkType>().toHaveProperty('_type')
-    type MarkTypeNames = MarkType['_type']
-    expectTypeOf<'link'>().toMatchTypeOf<MarkTypeNames>()
+    // When passing TypeGen content to PortableText, the `components.marks`
+    // should autocomplete with marks from the block markDefs union.
+    ;<PortableText
+      value={content}
+      components={{
+        marks: {
+          link: ({value}) => {
+            expectTypeOf(value).toEqualTypeOf<
+              PortableTextMarkComponentProps<Extract<MarkType, {_type: 'link'}>>['value']
+            >()
+            return null
+          },
+          glossaryTerm: ({value}) => {
+            expectTypeOf(value).toEqualTypeOf<
+              PortableTextMarkComponentProps<Extract<MarkType, {_type: 'glossaryTerm'}>>['value']
+            >()
+            return null
+          },
+        },
+      }}
+    />
   })
 
-  test('should be able to extract block styles', async () => {
+  test('should infer block styles in components.block from post content', async () => {
     const post = await fetchPost('foo')
+    const content = post?.content
     type PostData = NonNullable<typeof post>
     type PostContent = NonNullable<PostData['content']>
     type PostContentBlock = PostContent[number]
-
     type BlockType = Extract<PostContentBlock, {_type: 'block'}>
-    type StyleType = NonNullable<BlockType['style']>
 
-    // Post content supports: normal, h2, h3, blockquote
-    expectTypeOf<'normal'>().toMatchTypeOf<StyleType>()
-    expectTypeOf<'h2'>().toMatchTypeOf<StyleType>()
-    expectTypeOf<'h3'>().toMatchTypeOf<StyleType>()
-    expectTypeOf<'blockquote'>().toMatchTypeOf<StyleType>()
+    // When passing TypeGen content to PortableText, the `components.block`
+    // should autocomplete with styles from the block style union.
+    ;<PortableText
+      value={content}
+      components={{
+        block: {
+          normal: ({value}) => {
+            expectTypeOf(value.style).toEqualTypeOf<'normal' | undefined>()
+            expectTypeOf(value).toMatchTypeOf<PortableTextComponentProps<BlockType>['value']>()
+            return null
+          },
+          h2: ({value}) => {
+            expectTypeOf(value.style).toEqualTypeOf<'h2' | undefined>()
+            expectTypeOf(value).toMatchTypeOf<PortableTextComponentProps<BlockType>['value']>()
+            return null
+          },
+          h3: ({value}) => {
+            expectTypeOf(value.style).toEqualTypeOf<'h3' | undefined>()
+            expectTypeOf(value).toMatchTypeOf<PortableTextComponentProps<BlockType>['value']>()
+            return null
+          },
+          blockquote: ({value}) => {
+            expectTypeOf(value.style).toEqualTypeOf<'blockquote' | undefined>()
+            expectTypeOf(value).toMatchTypeOf<PortableTextComponentProps<BlockType>['value']>()
+            return null
+          },
+          lead: ({value}) => {
+            expectTypeOf(value.style).toEqualTypeOf<'lead' | undefined>()
+            expectTypeOf(value).toMatchTypeOf<PortableTextComponentProps<BlockType>['value']>()
+            return null
+          },
+        },
+      }}
+    />
+  })
+
+  test('should infer list styles in components.list and components.listItem from post content', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+    type PostData = NonNullable<typeof post>
+    type PostContent = NonNullable<PostData['content']>
+    type PostContentBlock = PostContent[number]
+    type BlockType = Extract<PostContentBlock, {_type: 'block'}>
+    type ListItemType = NonNullable<BlockType['listItem']>
+
+    expectTypeOf<'checklist'>().toMatchTypeOf<ListItemType>()
+    expectTypeOf<'steps'>().toMatchTypeOf<ListItemType>()
+
+    // When passing TypeGen content to PortableText, `components.list` and
+    // `components.listItem` should autocomplete with the block listItem union.
+    ;<PortableText
+      value={content}
+      components={{
+        list: {
+          checklist: ({value}) => {
+            expectTypeOf(value.listItem).toEqualTypeOf<'checklist'>()
+            return null
+          },
+          steps: ({value}) => {
+            expectTypeOf(value.listItem).toEqualTypeOf<'steps'>()
+            return null
+          },
+          legacyList: ({value}) => {
+            expectTypeOf(value).toBeAny()
+            return null
+          },
+        },
+        listItem: {
+          checklist: ({value}) => {
+            expectTypeOf(value.listItem).toEqualTypeOf<'checklist'>()
+            expectTypeOf(value).toMatchTypeOf<PortableTextComponentProps<BlockType>['value']>()
+            return null
+          },
+          steps: ({value}) => {
+            expectTypeOf(value.listItem).toEqualTypeOf<'steps'>()
+            expectTypeOf(value).toMatchTypeOf<PortableTextComponentProps<BlockType>['value']>()
+            return null
+          },
+          legacyList: ({value}) => {
+            expectTypeOf(value).toBeAny()
+            return null
+          },
+        },
+      }}
+    />
+  })
+
+  test('author bio should not offer image/quote/code in components.types', async () => {
+    const author = await fetchAuthor('123')
+    const bio = author?.bio
+
+    // Since author bio only has block type (no custom types),
+    // components.types should not autocomplete with 'image', 'quote', 'code'
+    ;<PortableText
+      value={bio}
+      components={{
+        types: {
+          image: ({value}) => {
+            expectTypeOf(value).toBeAny()
+            return null
+          },
+          quote: ({value}) => {
+            expectTypeOf(value).toBeAny()
+            return null
+          },
+          code: ({value}) => {
+            expectTypeOf(value).toBeAny()
+            return null
+          },
+        },
+      }}
+    />
+  })
+
+  test('author bio should not infer custom list styles in components.list or components.listItem', async () => {
+    const author = await fetchAuthor('123')
+    const bio = author?.bio
+    type AuthorData = NonNullable<typeof author>
+    type AuthorBio = NonNullable<AuthorData['bio']>
+    type AuthorBioBlock = AuthorBio[number]
+    type BlockType = Extract<AuthorBioBlock, {_type: 'block'}>
+    type ListItemType = NonNullable<BlockType['listItem']>
+
+    expectTypeOf<ListItemType>().toEqualTypeOf<never>()
+
+    // Since author bio has no list styles, custom list/listItem handlers are
+    // allowed but should not get precise TypeGen value props.
+    ;<PortableText
+      value={bio}
+      components={{
+        list: {
+          checklist: ({value}) => {
+            expectTypeOf(value).toBeAny()
+            return null
+          },
+        },
+        listItem: {
+          checklist: ({value}) => {
+            expectTypeOf(value).toBeAny()
+            return null
+          },
+        },
+      }}
+    />
+  })
+
+  test('author bio should only infer normal in components.block', async () => {
+    const author = await fetchAuthor('123')
+    const bio = author?.bio
+    type AuthorData = NonNullable<typeof author>
+    type AuthorBio = NonNullable<AuthorData['bio']>
+    type AuthorBioBlock = AuthorBio[number]
+    type BlockType = Extract<AuthorBioBlock, {_type: 'block'}>
+
+    // Since author bio only has normal blocks,
+    // components.block should autocomplete with 'normal' but not richer post styles.
+    ;<PortableText
+      value={bio}
+      components={{
+        block: {
+          normal: ({value}) => {
+            expectTypeOf(value.style).toEqualTypeOf<'normal' | undefined>()
+            expectTypeOf(value).toMatchTypeOf<PortableTextComponentProps<BlockType>['value']>()
+            return null
+          },
+          h2: ({value}) => {
+            expectTypeOf(value).toBeAny()
+            return null
+          },
+          h3: ({value}) => {
+            expectTypeOf(value).toBeAny()
+            return null
+          },
+          blockquote: ({value}) => {
+            expectTypeOf(value).toBeAny()
+            return null
+          },
+        },
+      }}
+    />
+  })
+
+  test('defining a type handler for a type NOT in content should be allowed by default', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+    type PostData = NonNullable<typeof post>
+    type PostContent = NonNullable<PostData['content']>
+    type PostContentBlock = PostContent[number]
+    type CustomTypes = Exclude<PostContentBlock, {_type: 'block'}>
+
+    // For the "forgiving" default behavior:
+    // If I define a handler for a type that doesn't exist in the content,
+    // TypeScript should NOT error. This supports the case where:
+    // - Old content might still have that type
+    // - The handler is shared across multiple content types
+    ;<PortableText
+      value={content}
+      components={{
+        types: {
+          image: ({value}) => {
+            expectTypeOf(value).toEqualTypeOf<
+              PortableTextTypeComponentProps<Extract<CustomTypes, {_type: 'image'}>>['value']
+            >()
+            return null
+          },
+          // This type doesn't exist in our schema but should be allowed
+          legacyEmbed: ({value}) => {
+            expectTypeOf(value).toBeAny()
+            return null
+          },
+        },
+      }}
+    />
   })
 })
 
-describe('TypeGen components inference for author bio', () => {
+describe('InferStrictComponents utility type', () => {
+  // This utility type should:
+  // - Require handlers for all custom types in the content
+  // - Disallow extra handlers (strict mode)
+
   test('author bio should only have block type (no custom types)', async () => {
     const author = await fetchAuthor('123')
     type AuthorData = NonNullable<typeof author>
@@ -143,140 +426,605 @@ describe('TypeGen components inference for author bio', () => {
     type StyleType = NonNullable<BlockType['style']>
     expectTypeOf<StyleType>().toEqualTypeOf<'normal'>()
   })
-})
 
-describe('Desired: PortableText component with TypeGen types', () => {
-  test('should infer custom types in components.types from post content (currently not inferred)', async () => {
+  test('requires all custom handlers and disallows extras', async () => {
     const post = await fetchPost('foo')
-    const content = post!.content!
+    const content = post?.content
+    type PostData = NonNullable<typeof post>
+    type PostContent = NonNullable<PostData['content']>
+    type PostContentBlock = PostContent[number]
+    type CustomTypes = Exclude<PostContentBlock, {_type: 'block'}>
+    type BlockType = Extract<PostContentBlock, {_type: 'block'}>
+    type MarkDefs = NonNullable<BlockType['markDefs']>
+    type MarkType = MarkDefs[number]
 
-    // When passing TypeGen content to PortableText, the `components.types`
-    // should autocomplete with 'image', 'quote', 'code' from the content union.
-    // Currently PortableText doesn't infer component types from the value prop.
-    ;<PortableText
-      value={content}
-      components={{
-        types: {
-          image: ({value}) => {
-            assertType<{_type: string}>(value)
-            return null
-          },
-          quote: ({value}) => {
-            assertType<{_type: string}>(value)
-            return null
-          },
-          code: ({value}) => {
-            assertType<{_type: string}>(value)
-            return null
-          },
+    const components = {
+      types: {
+        image: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<
+            PortableTextTypeComponentProps<Extract<CustomTypes, {_type: 'image'}>>['value']
+          >()
+          return null
         },
-      }}
-    />
+        quote: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<
+            PortableTextTypeComponentProps<Extract<CustomTypes, {_type: 'quote'}>>['value']
+          >()
+          return null
+        },
+        code: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<
+            PortableTextTypeComponentProps<Extract<CustomTypes, {_type: 'code'}>>['value']
+          >()
+          return null
+        },
+      },
+      marks: {
+        // `link` is handled by default, so only the custom annotation is required.
+        glossaryTerm: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<
+            PortableTextMarkComponentProps<Extract<MarkType, {_type: 'glossaryTerm'}>>['value']
+          >()
+          return null
+        },
+      },
+      block: {
+        // Default block styles are handled by default, so only `lead` is required.
+        lead: ({value}) => {
+          expectTypeOf(value.style).toEqualTypeOf<'lead' | undefined>()
+          expectTypeOf(value).toMatchTypeOf<PortableTextComponentProps<BlockType>['value']>()
+          return null
+        },
+      },
+      list: {
+        // `number` and `bullet` are handled by default, so only custom list styles are required.
+        checklist: ({value}) => {
+          expectTypeOf(value.listItem).toEqualTypeOf<'checklist'>()
+          return null
+        },
+        steps: ({value}) => {
+          expectTypeOf(value.listItem).toEqualTypeOf<'steps'>()
+          return null
+        },
+      },
+      // `listItem` is intentionally omitted: the default top-level function handles all list item styles.
+    } satisfies InferStrictComponents<typeof content>
+
+    ;<PortableText value={content} components={components} />
   })
 
-  test('author bio should not offer image/quote/code in components.types (currently not inferred)', async () => {
+  test('errors when a custom type handler is missing', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+
+    const components = {
+      // @ts-expect-error Missing required `code` type handler
+      types: {
+        image: () => null,
+        quote: () => null,
+      },
+    } satisfies InferStrictComponents<typeof content>
+
+    ;<PortableText value={content} components={components} />
+  })
+
+  test('errors when a custom mark handler is missing', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+
+    const components = {
+      types: {
+        image: () => null,
+        quote: () => null,
+        code: () => null,
+      },
+      // @ts-expect-error Missing required `glossaryTerm` mark handler
+      marks: {},
+      block: {
+        lead: () => null,
+      },
+      list: {
+        checklist: () => null,
+        steps: () => null,
+      },
+    } satisfies InferStrictComponents<typeof content>
+
+    ;<PortableText value={content} components={components} />
+  })
+
+  test('errors when a mark handler is not inferred or handled by default', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+
+    const components = {
+      types: {
+        image: () => null,
+        quote: () => null,
+        code: () => null,
+      },
+      marks: {
+        glossaryTerm: () => null,
+        link: () => null,
+        // @ts-expect-error `legacyMark` is not inferred and not handled by default
+        legacyMark: () => null,
+      },
+      block: {
+        lead: () => null,
+      },
+      list: {
+        checklist: () => null,
+        steps: () => null,
+      },
+    } satisfies InferStrictComponents<typeof content>
+
+    ;<PortableText value={content} components={components} />
+  })
+
+  test('errors when a custom block style handler is missing', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+
+    const components = {
+      types: {
+        image: () => null,
+        quote: () => null,
+        code: () => null,
+      },
+      marks: {
+        glossaryTerm: () => null,
+      },
+      // @ts-expect-error Missing required `lead` block style handler
+      block: {},
+      list: {
+        checklist: () => null,
+        steps: () => null,
+      },
+    } satisfies InferStrictComponents<typeof content>
+
+    ;<PortableText value={content} components={components} />
+  })
+
+  test('errors when a block style handler is not inferred or handled by default', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+
+    const components = {
+      types: {
+        image: () => null,
+        quote: () => null,
+        code: () => null,
+      },
+      marks: {
+        glossaryTerm: () => null,
+      },
+      block: {
+        lead: () => null,
+        h2: () => null,
+        // @ts-expect-error `legacyStyle` is not inferred and not handled by default
+        legacyStyle: () => null,
+      },
+      list: {
+        checklist: () => null,
+        steps: () => null,
+      },
+    } satisfies InferStrictComponents<typeof content>
+
+    ;<PortableText value={content} components={components} />
+  })
+
+  test('errors when a custom list style handler is missing', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+
+    const components = {
+      types: {
+        image: () => null,
+        quote: () => null,
+        code: () => null,
+      },
+      marks: {
+        glossaryTerm: () => null,
+      },
+      block: {
+        lead: () => null,
+      },
+      // @ts-expect-error Missing required `steps` list style handler
+      list: {
+        checklist: () => null,
+      },
+    } satisfies InferStrictComponents<typeof content>
+
+    ;<PortableText value={content} components={components} />
+  })
+
+  test('errors when a list style handler is not inferred from the content', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+
+    const components = {
+      types: {
+        image: () => null,
+        quote: () => null,
+        code: () => null,
+      },
+      marks: {
+        glossaryTerm: () => null,
+      },
+      block: {
+        lead: () => null,
+      },
+      list: {
+        checklist: () => null,
+        steps: () => null,
+        // @ts-expect-error `bullet` is handled by default, but is not in the content type union
+        bullet: () => null,
+      },
+    } satisfies InferStrictComponents<typeof content>
+
+    ;<PortableText value={content} components={components} />
+  })
+
+  test('requires all inferred list item handlers when listItem is an object', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+
+    const components = {
+      types: {
+        image: () => null,
+        quote: () => null,
+        code: () => null,
+      },
+      marks: {
+        glossaryTerm: () => null,
+      },
+      block: {
+        lead: () => null,
+      },
+      list: {
+        checklist: () => null,
+        steps: () => null,
+      },
+      // @ts-expect-error Missing required `steps` list item handler
+      listItem: {
+        checklist: () => null,
+      },
+    } satisfies InferStrictComponents<typeof content>
+
+    ;<PortableText value={content} components={components} />
+  })
+
+  test('allows listItem as a function because it handles all list item styles', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+
+    const components = {
+      types: {
+        image: () => null,
+        quote: () => null,
+        code: () => null,
+      },
+      marks: {
+        glossaryTerm: () => null,
+      },
+      block: {
+        lead: () => null,
+      },
+      list: {
+        checklist: () => null,
+        steps: () => null,
+      },
+      listItem: ({children}) => {
+        return <li>{children}</li>
+      },
+    } satisfies InferStrictComponents<typeof content>
+
+    ;<PortableText value={content} components={components} />
+  })
+
+  test('errors when a custom type handler is not in the content', async () => {
+    const post = await fetchPost('foo')
+    const content = post?.content
+
+    const components = {
+      types: {
+        image: () => null,
+        quote: () => null,
+        code: () => null,
+        // @ts-expect-error `legacyEmbed` is not in the content type union
+        legacyEmbed: () => null,
+      },
+    } satisfies InferStrictComponents<typeof content>
+
+    ;<PortableText value={content} components={components} />
+  })
+
+  test('does not require type handlers when content has no custom types', async () => {
     const author = await fetchAuthor('123')
-    const bio = author!.bio!
+    const bio = author?.bio
 
-    // Since author bio only has block type (no custom types),
-    // components.types should not autocomplete with 'image', 'quote', 'code'
-    ;<PortableText
-      value={bio}
-      components={{
-        types: {},
-      }}
-    />
+    const components = {} satisfies InferStrictComponents<typeof bio>
+
+    ;<PortableText value={bio} components={components} />
   })
 
-  test('defining a type handler for a type NOT in content should be allowed by default', async () => {
-    const post = await fetchPost('foo')
-    const content = post!.content!
+  test('does not allow overriding default handles if they are not used in the content', async () => {
+    const author = await fetchAuthor('123')
+    const bio = author?.bio
+    type BioData = NonNullable<typeof bio>
+    type BioDataBlocks = BioData[number]
+    type BlockType = Extract<BioDataBlocks, {_type: 'block'}>
 
-    // For the "forgiving" default behavior:
-    // If I define a handler for a type that doesn't exist in the content,
-    // TypeScript should NOT error. This supports the case where:
-    // - Old content might still have that type
-    // - The handler is shared across multiple content types
-    ;<PortableText
-      value={content}
-      components={{
-        types: {
-          image: ({value}) => {
-            assertType<{_type: string}>(value)
-            return null
-          },
-          // This type doesn't exist in our schema but should be allowed
-          legacyEmbed: ({value}) => {
-            assertType<{_type: string}>(value)
-            return null
-          },
+    const components = {
+      block: {
+        normal: ({value}) => {
+          expectTypeOf(value.style).toEqualTypeOf<'normal' | undefined>()
+          expectTypeOf(value).toMatchTypeOf<PortableTextComponentProps<BlockType>['value']>()
+          return null
         },
-      }}
-    />
+        // @ts-expect-error `h1` is not in the content type union
+        h1: () => null,
+      },
+    } satisfies InferStrictComponents<typeof bio>
+
+    ;<PortableText value={bio} components={components} />
+  })
+
+  test('errors on type handlers when content has no custom types', async () => {
+    const author = await fetchAuthor('123')
+    const bio = author?.bio
+
+    const components = {
+      types: {
+        // @ts-expect-error Author bio has no custom type handlers
+        legacyEmbed: () => null,
+      },
+    } satisfies InferStrictComponents<typeof bio>
+
+    ;<PortableText value={bio} components={components} />
   })
 })
 
-describe('Desired: InferPortableTextComponents utility type', () => {
-  // This utility type should:
-  // - Require handlers for all custom types in the content
-  // - Allow extra handlers (forgiving for types not in the current schema)
+describe('InferValue utility type', () => {
+  test('extracts portable text members from all schema types', () => {
+    type PortableTextValue = InferValue<AllSanitySchemaTypes>
+    type PortableTextItem = PortableTextValue[number]
+    type TypeNames = PortableTextItem['_type']
 
-  test.skip('documents the desired InferPortableTextComponents behavior', () => {
-    // In the future, we want to expose:
-    // type InferPortableTextComponents<T> = ...
-    //
-    // Usage:
-    // const components = {
-    //   types: {
-    //     image: ({value}) => <Image {...value} />,
-    //     quote: ({value}) => <blockquote>{value.text}</blockquote>,
-    //     code: ({value}) => <pre>{value.code}</pre>,
-    //     // missing one? TypeScript should error because 'code' etc might be needed
-    //   }
-    // } satisfies InferPortableTextComponents<typeof data.content>
-    //
-    // Extra types (like `legacyEmbed`) should be allowed
-    // Missing required types (like omitting `image`) should error
+    expectTypeOf<'block'>().toMatchTypeOf<TypeNames>()
+    expectTypeOf<'image'>().toMatchTypeOf<TypeNames>()
+    expectTypeOf<'quote'>().toMatchTypeOf<TypeNames>()
+    expectTypeOf<'code'>().toMatchTypeOf<TypeNames>()
+    expectTypeOf<'featuredPost'>().toMatchTypeOf<TypeNames>()
+
+    type CustomTypes = Exclude<PortableTextItem, {_type: 'block'}>
+    expectTypeOf<Extract<CustomTypes, {_type: 'featuredPost'}>>().toHaveProperty('post')
+
+    type BlockType = Extract<PortableTextItem, {_type: 'block'}>
+    type StyleType = NonNullable<BlockType['style']>
+    expectTypeOf<'normal'>().toMatchTypeOf<StyleType>()
+    expectTypeOf<'lead'>().toMatchTypeOf<StyleType>()
+
+    type ListItemType = NonNullable<BlockType['listItem']>
+    expectTypeOf<'checklist'>().toMatchTypeOf<ListItemType>()
+    expectTypeOf<'steps'>().toMatchTypeOf<ListItemType>()
+
+    type MarkDefs = NonNullable<BlockType['markDefs']>
+    type MarkType = MarkDefs[number]
+    type MarkTypeNames = MarkType['_type']
+    expectTypeOf<'link'>().toMatchTypeOf<MarkTypeNames>()
+    expectTypeOf<'glossaryTerm'>().toMatchTypeOf<MarkTypeNames>()
   })
-})
 
-describe('Desired: InferStrictPortableTextComponents utility type', () => {
-  // This utility type should:
-  // - Require handlers for all custom types in the content
-  // - Disallow extra handlers (strict mode)
+  test('works as input to InferStrictComponents and PortableText', () => {
+    type PortableTextValue = InferValue<AllSanitySchemaTypes>
+    type PortableTextItem = PortableTextValue[number]
+    type CustomTypes = Exclude<PortableTextItem, {_type: 'block'}>
+    type BlockType = Extract<PortableTextItem, {_type: 'block'}>
+    type MarkDefs = NonNullable<BlockType['markDefs']>
+    type MarkType = MarkDefs[number]
 
-  test.skip('documents the desired InferStrictPortableTextComponents behavior', () => {
-    // In the future, we want to expose:
-    // type InferStrictPortableTextComponents<T> = ...
-    //
-    // Usage:
-    // const components = {
-    //   types: {
-    //     image: ({value}) => <Image {...value} />,
-    //     foo: () => <div/>, // ERROR: 'foo' is not in the content types
-    //   }
-    // } satisfies InferStrictPortableTextComponents<typeof data.content>
-    //
-    // Both missing AND extra types should cause TypeScript errors
+    const components = {
+      types: {
+        image: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<
+            PortableTextTypeComponentProps<Extract<CustomTypes, {_type: 'image'}>>['value']
+          >()
+          return null
+        },
+        quote: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<
+            PortableTextTypeComponentProps<Extract<CustomTypes, {_type: 'quote'}>>['value']
+          >()
+          return null
+        },
+        code: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<
+            PortableTextTypeComponentProps<Extract<CustomTypes, {_type: 'code'}>>['value']
+          >()
+          return null
+        },
+        featuredPost: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<
+            PortableTextTypeComponentProps<Extract<CustomTypes, {_type: 'featuredPost'}>>['value']
+          >()
+          return null
+        },
+      },
+      marks: {
+        glossaryTerm: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<
+            PortableTextMarkComponentProps<Extract<MarkType, {_type: 'glossaryTerm'}>>['value']
+          >()
+          return null
+        },
+        link: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<
+            PortableTextMarkComponentProps<Extract<MarkType, {_type: 'link'}>>['value']
+          >()
+          return null
+        },
+      },
+      block: {
+        lead: ({value}) => {
+          expectTypeOf(value.style).toEqualTypeOf<'lead' | undefined>()
+          expectTypeOf(value).toMatchTypeOf<PortableTextComponentProps<BlockType>['value']>()
+          return null
+        },
+      },
+      list: {
+        checklist: ({value}) => {
+          expectTypeOf(value.listItem).toEqualTypeOf<'checklist'>()
+          return null
+        },
+        steps: ({value}) => {
+          expectTypeOf(value.listItem).toEqualTypeOf<'steps'>()
+          return null
+        },
+      },
+    } satisfies InferStrictComponents<PortableTextValue>
+
+    const value = [] as PortableTextValue
+    ;<PortableText components={components} value={value} />
   })
-})
 
-describe('Desired: value prop typed component inference', () => {
-  test.skip('image handler value should be typed from TypeGen when passing content directly', () => {
-    // When we pass TypeGen content to PortableText, the image handler's `value`
-    // should be automatically typed as the image type from the content union:
-    //
-    // type ImageBlock = {
-    //   asset?: SanityImageAssetReference;
-    //   media?: unknown;
-    //   hotspot?: SanityImageHotspot;
-    //   crop?: SanityImageCrop;
-    //   alt?: string;
-    //   caption?: string;
-    //   _type: "image";
-    //   _key: string;
-    // }
-    //
-    // Currently, the value is typed as `any` regardless of what's passed to `value`
+  test('works as input to InferComponents for hoisted partial components', () => {
+    type PortableTextValue = InferValue<AllSanitySchemaTypes>
+    type PortableTextItem = PortableTextValue[number]
+
+    const components = {
+      types: {
+        featuredPost: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<
+            PortableTextTypeComponentProps<
+              Extract<PortableTextItem, {_type: 'featuredPost'}>
+            >['value']
+          >()
+          return null
+        },
+        legacyEmbed: ({value}) => {
+          expectTypeOf(value).toBeAny()
+          return null
+        },
+      },
+    } satisfies InferComponents<PortableTextValue>
+
+    const value = [] as PortableTextValue
+    ;<PortableText components={components} value={value} />
+  })
+
+  test('can handle SanityQueries', async () => {
+    const author = await fetchAuthor('123')
+    const category = await fetchCategory('456')
+    type PortableTextValue = InferValue<typeof author | typeof category>
+
+    const components = {
+      block: {},
+      marks: {},
+      types: {
+        featuredPost: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<{
+            _key: string
+            _type: 'featuredPost'
+            post: {
+              title: string | null
+              author: {name: string | null; avatar: string | null} | null
+              slug: string | null
+            } | null
+          }>()
+          return null
+        },
+      },
+    } satisfies InferStrictComponents<PortableTextValue>
+
+    const value = [] as PortableTextValue
+    ;<PortableText components={components} value={value} />
+  })
+
+  test('can require handlers for all Portable Text returned by SanityQueries', () => {
+    type PortableTextValue = InferValue<SanityQueries[keyof SanityQueries]>
+
+    const components = {
+      types: {
+        image: () => null,
+        quote: () => null,
+        code: () => null,
+        featuredPost: ({value}) => {
+          expectTypeOf(value).toEqualTypeOf<{
+            _key: string
+            _type: 'featuredPost'
+            post: {
+              title: string | null
+              author: {name: string | null; avatar: string | null} | null
+              slug: string | null
+            } | null
+          }>()
+          return null
+        },
+      },
+      marks: {
+        glossaryTerm: () => null,
+      },
+      block: {
+        lead: () => null,
+      },
+      list: {
+        checklist: () => null,
+        steps: () => null,
+      },
+    } satisfies InferStrictComponents<PortableTextValue>
+
+    const value = [] as PortableTextValue
+    ;<PortableText components={components} value={value} />
+  })
+
+  test('can use a mock query technique to type props.value for a re-usable component', async () => {
+    // The point of this technique is an escape hatch that is faster than having to iterate over the entirety of `SanityQueries`
+    // as it can be a massive union of types, and only some of them are relevant to portable text
+
+    const mockQuery = defineQuery(`*[_type in ["author", "category", "post"]]{
+      _type == "author" => {bio},
+      _type == "category" => {
+        description[]{
+          ...,
+          _type == "featuredPost" => {
+            ...,
+            post->{title,author->{name,"avatar":avatar.asset->url},"slug":slug.current}
+          }
+        }
+      },
+      _type == "post" => {content},
+    }`)
+    function CustomPortableText({
+      value,
+    }: {
+      value: InferValue<SanityQueries[typeof mockQuery]> | null | undefined
+    }) {
+      const components = {
+        types: {
+          code: () => null,
+          featuredPost: () => null,
+          image: () => null,
+          quote: () => null,
+        },
+        marks: {
+          glossaryTerm: () => null,
+        },
+        block: {
+          lead: () => null,
+        },
+        list: {
+          checklist: () => null,
+          steps: () => null,
+        },
+      } satisfies InferStrictComponents<typeof value>
+      return <PortableText components={components} value={value} />
+    }
+    // The mock query technique should be compatible with the existing typegen queries
+    const author = await fetchAuthor('123')
+    ;<CustomPortableText value={author?.bio} />
+    const category = await fetchCategory('456')
+    ;<CustomPortableText value={category?.description} />
+    const post = await fetchPost('789')
+    ;<CustomPortableText value={post?.content} />
   })
 })


### PR DESCRIPTION
# TypeGen-aware Portable Text components

`<PortableText>` now infers the shape of every component handler from the `value` prop. When you pass a value typed by [Sanity TypeGen](https://www.sanity.io/docs/apis-and-sdks/sanity-typegen), `components.types`, `components.marks`, `components.block`, `components.list`, and `components.listItem` all receive precise `value` props for the exact content the query returned.

Three new utility types ship with this feature:

- `InferComponents<T>` - same inference as the inline `components` prop, for hoisting components out of JSX.
- `InferStrictComponents<T>` - strict variant that requires a handler for every inferred custom type, mark, block style, and list style, and rejects handlers that aren't in the schema (and therefore not visible to TypeGen).
- `InferValue<T>` - derives a Portable Text array value type from any TypeGen query result type, useful for re-usable wrapper components.

## Schema

Every example below assumes the same `sanity.config.ts`:

```ts
// sanity.config.ts
import {defineArrayMember, defineConfig, defineField, defineType} from 'sanity'

export default defineConfig({
  name: 'default',
  projectId: 'abc123',
  dataset: 'production',
  schema: {
    types: [
      defineType({
        name: 'post',
        type: 'document',
        fields: [
          defineField({name: 'title', type: 'string'}),
          defineField({
            name: 'content',
            type: 'array',
            of: [
              defineArrayMember({type: 'block'}),
              defineArrayMember({
                type: 'image',
                options: {hotspot: true},
                fields: [defineField({name: 'alt', type: 'string'})],
              }),
            ],
          }),
        ],
      }),
    ],
  },
})
```

## Before: hand-typing handlers

Previously, every handler had to be typed by hand to mirror the generated query shape:

```tsx
// app/[slug]/page.tsx
import {createClient} from '@sanity/client'
import {createImageUrlBuilder} from '@sanity/image-url'
import {PortableText} from '@portabletext/react'
import {defineQuery} from 'groq'

const client = createClient({
  projectId: 'abc123',
  dataset: 'production',
  useCdn: true,
  apiVersion: '2026-05-04',
})
const builder = createImageUrlBuilder(client)

export default async function Page({slug}: {slug: string}) {
  const query = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title,content}`)
  const data = await client.fetch(query, {slug})

  if (!data) return notFound()

  return (
    <article>
      <h1>{data.title}</h1>
      <PortableText
        components={{
          types: {
            image: ({
              value,
            }: {
              value: {
                asset?: {
                  _ref: string
                  _type: 'reference'
                  _weak?: boolean
                }
                hotspot?: {
                  _type: 'sanity.imageHotspot'
                  x?: number
                  y?: number
                  height?: number
                  width?: number
                }
                crop?: {
                  _type: 'sanity.imageCrop'
                  top?: number
                  bottom?: number
                  left?: number
                  right?: number
                }
                alt?: string
                _type: 'image'
                _key: string
              }
            }) => <img src={builder.image(value).url()} alt={value.alt || ''} />,
          },
        }}
        value={data.content}
      />
    </article>
  )
}
```

## After: automatic inference

Now the same handler is fully typed straight from `data.content`:

```tsx
// app/[slug]/page.tsx
import {createClient} from '@sanity/client'
import {createImageUrlBuilder} from '@sanity/image-url'
import {PortableText} from '@portabletext/react'
import {defineQuery} from 'groq'

const client = createClient({
  projectId: 'abc123',
  dataset: 'production',
  useCdn: true,
  apiVersion: '2026-05-04',
})
const builder = createImageUrlBuilder(client)

export default async function Page({slug}: {slug: string}) {
  const query = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title,content}`)
  const data = await client.fetch(query, {slug})

  if (!data) return notFound()

  return (
    <article>
      <h1>{data.title}</h1>
      <PortableText
        components={{
          types: {
            // value is fully typed from the query result, no annotation needed
            image: ({value}) => (
              <img src={builder.image(value).url()} alt={value.alt || ''} />
            ),
          },
        }}
        value={data.content}
      />
    </article>
  )
}
```

## `InferComponents`: hoisting components without losing inference

Move the `components` map out of JSX and keep the same inferred handler types:

```tsx
// app/[slug]/page.tsx
import {createClient} from '@sanity/client'
import {createImageUrlBuilder} from '@sanity/image-url'
import {PortableText, type InferComponents} from '@portabletext/react'
import {defineQuery} from 'groq'

const client = createClient({
  projectId: 'abc123',
  dataset: 'production',
  useCdn: true,
  apiVersion: '2026-05-04',
})
const builder = createImageUrlBuilder(client)

export default async function Page({slug}: {slug: string}) {
  const query = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title,content}`)
  const data = await client.fetch(query, {slug})

  if (!data) return notFound()

  const components = {
    types: {
      image: ({value}) => <img src={builder.image(value).url()} alt={value.alt || ''} />,
    },
  } satisfies InferComponents<typeof data.content>

  return (
    <article>
      <h1>{data.title}</h1>
      <PortableText components={components} value={data.content} />
    </article>
  )
}
```

## `InferStrictComponents` + `InferValue`: a strict, re-usable wrapper

`InferValue<SanityQueries[keyof SanityQueries]>` collects every Portable Text item shape from every registered TypeGen query into an array value type, and `InferStrictComponents` requires a handler for each of them. Together they're perfect for a single `CustomPortableText` you reuse across the app:

```tsx
// app/[slug]/page.tsx
import {createClient, type SanityQueries} from '@sanity/client'
import {createImageUrlBuilder} from '@sanity/image-url'
import {
  PortableText,
  type InferStrictComponents,
  type InferValue,
} from '@portabletext/react'
import {defineQuery} from 'groq'

const client = createClient({
  projectId: 'abc123',
  dataset: 'production',
  useCdn: true,
  apiVersion: '2026-05-04',
})
const builder = createImageUrlBuilder(client)

// Array value type for every Portable Text item shape across all registered queries.
type PortableTextValue = InferValue<SanityQueries[keyof SanityQueries]>

function CustomPortableText({value}: {value: PortableTextValue}) {
  const components = {
    types: {
      image: ({value}) => <img src={builder.image(value).url()} alt={value.alt || ''} />,
    },
  } satisfies InferStrictComponents<PortableTextValue>
  //   ^ TypeScript errors when the schema gains a custom type, mark, or list
  //     style without a matching handler defined here

  return <PortableText components={components} value={value} />
}

export default async function Page({slug}: {slug: string}) {
  const query = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title,content}`)
  const data = await client.fetch(query, {slug})

  if (!data) return notFound()

  return (
    <article>
      <h1>{data.title}</h1>
      {Array.isArray(data.content) && <CustomPortableText value={data.content} />}
    </article>
  )
}
```
