### PR TITLE
feat!: compile with React Compiler, ship an uncompiled react-server build for RSC

### DIFF
--- a/.changeset/react-server-dual-build.md
+++ b/.changeset/react-server-dual-build.md
@@ -1,0 +1,17 @@
+---
+'@portabletext/react': major
+---
+
+`<PortableText>` now ships as two builds selected by export conditions: the `default` build is optimized with [React Compiler](https://react.dev/learn/react-compiler) auto-memoization, and an uncompiled build serves the `react-server` condition, since React Server Components refuse to load compiled output ([facebook/react#31702](https://github.com/facebook/react/issues/31702)):
+
+```json
+".": {
+  "types": "./dist/index.d.ts",
+  "react-server": "./dist/index.react-server.js",
+  "default": "./dist/index.js"
+}
+```
+
+There are no API changes. Client components and SSR get the compiled build, with finer-grained memoization than the manual `useMemo` calls it replaces, and server components render the same source uncompiled — they render exactly once, so memoization can never pay off there.
+
+**BREAKING**: React 19 is now required (`peerDependencies.react` is `^19`) — the compiled build loads `react/compiler-runtime`, which only exists in React 19. Stay on `@portabletext/react@6` if you are on React 18.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,21 @@ jobs:
       - run: pnpm lint -f github
       - run: pnpm build
 
+  test-next:
+    runs-on: ubuntu-latest
+    name: Next.js RSC integration
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v7
+        with:
+          cache: pnpm
+          node-version: lts/*
+      - run: pnpm install
+      # Packs the library with `pnpm pack`, installs the tarball into test/next-app (a
+      # next@preview app) and asserts a pure RSC route and a 'use client' route both render
+      - run: pnpm test:next
+
   test:
     runs-on: ${{ matrix.platform }}
     name: Node.js ${{ matrix.node-version }} / ${{ matrix.platform }}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -5,7 +5,10 @@
     "coverage/**",
     "demo/dist/**",
     ".nyc_output/**",
-    "test/typegen/sanity.types.ts"
+    "test/typegen/sanity.types.ts",
+    // The Next.js integration fixture resolves `next` types from its own node_modules, which
+    // only exist while `pnpm test:next` runs - type-aware linting can't see them from the root
+    "test/next-app/**"
   ],
   "plugins": ["eslint", "typescript", "unicorn", "react", "react-perf", "oxc", "import"],
   "categories": {

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,3 +1,10 @@
+# Migrating to @portabletext/react v7
+
+v7 has no API changes — `<PortableText>` accepts the same props and renders the same output as v6. What changed is how the library is built, and which React versions it supports:
+
+- **React 19 is required.** The published client build is optimized with [React Compiler](https://react.dev/learn/react-compiler), whose runtime (`react/compiler-runtime`) only exists in React 19. If you're on React 18, stay on `@portabletext/react@6`.
+- **React Server Components keep working — without the compiler overhead.** The package now publishes two entrypoints via export conditions: server components resolve an uncompiled build (the `react-server` condition) since [RSC refuses to load React Compiler output](https://github.com/facebook/react/issues/31702), while client components and SSR resolve the compiled one. Bundlers and runtimes pick the right build automatically; there is nothing to configure.
+
 # Migrating to @portabletext/react v2
 
 `@portabletext/react@1` allowed configuring custom components through React context. In v2, this functionality has been removed in order to allow using the component with [React Server Components](https://reactjs.org/blog/2020/12/21/data-fetching-with-react-server-components.html) (RSC).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Migrating from [@sanity/block-content-to-react](https://www.npmjs.com/package/@s
 
 - [Installation](#installation)
 - [Basic usage](#basic-usage)
+- [React Server Components](#react-server-components)
 - [Styling](#styling-the-output)
 - [Customizing components](#customizing-components)
 - [Available components](#available-components)
@@ -44,6 +45,10 @@ import {PortableText} from '@portabletext/react'
   components={/* optional object of custom components to use */}
 />
 ```
+
+## React Server Components
+
+`<PortableText>` renders in both worlds without configuration: use it directly in a React Server Component, or in a file with a `'use client'` directive. The package publishes two builds selected automatically through export conditions — client components and SSR load a build optimized with [React Compiler](https://react.dev/learn/react-compiler), while server components load an uncompiled build through the `react-server` condition ([React Compiler output can't load in server components](https://github.com/facebook/react/issues/31702), and since server components render exactly once, memoization couldn't pay off there anyway).
 
 ## Styling the output
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,11 @@
   },
   "publishConfig": {
     "exports": {
-      ".": "./dist/index.js",
+      ".": {
+        "types": "./dist/index.d.ts",
+        "react-server": "./dist/index.react-server.js",
+        "default": "./dist/index.js"
+      },
       "./package.json": "./package.json"
     }
   },
@@ -58,7 +62,7 @@
     "@sanity/client": "^7.24.0",
     "@sanity/image-url": "^2.1.1",
     "@sanity/tsconfig": "^2.2.1",
-    "@sanity/tsdown-config": "^0.19.6",
+    "@sanity/tsdown-config": "^0.21.0",
     "@sanity/ui": "^3.4.3",
     "@types/leaflet": "^1.9.21",
     "@types/react": "^19.2.17",
@@ -89,7 +93,7 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
-    "react": "^18.2 || ^19"
+    "react": "^19"
   },
   "lint-staged": {
     "*": [

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "release": "changeset publish",
     "start": "pnpm dev",
     "test": "vitest",
+    "test:next": "node test/next-app/run.mjs",
     "typegen": "(cd test/typegen && sanity schema extract && sanity typegen generate)",
     "type-check": "tsc --noEmit -p tsconfig.dist.json"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^2.2.1
         version: 2.2.1
       '@sanity/tsdown-config':
-        specifier: ^0.19.6
-        version: 0.19.6(@babel/runtime@7.29.7)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.0)(tsdown@0.22.13(publint@0.3.22)(tsx@4.23.1)(typescript@7.0.2))(typescript@7.0.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^0.21.0
+        version: 0.21.0(@babel/runtime@7.29.7)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.0)(tsdown@0.22.13(publint@0.3.22)(tsx@4.23.1)(typescript@7.0.2))(typescript@7.0.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@sanity/ui':
         specifier: ^3.4.3
         version: 3.4.3(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
@@ -2400,8 +2400,8 @@ packages:
   '@sanity/tsconfig@2.2.1':
     resolution: {integrity: sha512-1HbvN+W2bWixgXQnvJ9rev5vJaSbN62d+r0Y2pN6XsK6/MP9JfVyF90elBuIrDENTGgVmxB403+gZow45wq+Pg==}
 
-  '@sanity/tsdown-config@0.19.6':
-    resolution: {integrity: sha512-Ihj7zJsjHKe9edZxUS3P1c4DN2danKLbkzVqPR0hQp+QIluqjCBk0TM/Zs0SfNFspbP0WcnzRCNZx0tdviloNA==}
+  '@sanity/tsdown-config@0.21.0':
+    resolution: {integrity: sha512-hrPrw61DeK5usXxzYrjoXv3wAohcOe77u/vFA5BqvyD4ATLHLw13645KLSfNYacgUeTuyk4DaO7UAaAXRPt0lQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       babel-plugin-react-compiler: '*'
@@ -2432,12 +2432,12 @@ packages:
   '@sanity/uuid@3.0.3':
     resolution: {integrity: sha512-aJvKuFwzcZKRwuIjrRPfXfXKpSdnLF4CnedV5WcX1n5SzhufvRNHIot5lkx1+Y1DwiMVQOZ5gDSPJH+P6Ao70A==}
 
-  '@sanity/vanilla-extract-integration@0.1.5':
-    resolution: {integrity: sha512-yboyCtrKafxybzF4KgU8E3C1fQmFF5Lll+J0t9ojjEHC6sQrzPDpGGXRE8e74NWAeHKFrCUde6aQ5N7caIpm6Q==}
+  '@sanity/vanilla-extract-integration@0.1.6':
+    resolution: {integrity: sha512-Gfd6/2IHd1+99YavyIKBw2gLcvcHCVhmGYSkY0gWXTvLB81hAAOHDfTlzmiTbSCNZxAK+V8WqBupxVol/ZgTGQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
-  '@sanity/vanilla-extract-rolldown-plugin@0.3.2':
-    resolution: {integrity: sha512-UoV1ojiFg5EB+SWn0YdY/SRPnETrWNECuiqPIYM8wlVYxr9U/5Sus3jd2DoMNOZzrEMBwdO27V1W5awZTrqHaw==}
+  '@sanity/vanilla-extract-rolldown-plugin@0.3.3':
+    resolution: {integrity: sha512-I7HTy6EmzRxeR5KdqdidPuZFB3ytLOxYBjw4k1YrDgjlx/wTSSP+jlcho3QIXRm+7JsHtITc/IsdMZj6FzhB3w==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       rolldown: ^1.0.0
@@ -2445,8 +2445,8 @@ packages:
       rolldown:
         optional: true
 
-  '@sanity/vanilla-extract-tsdown-plugin@0.2.8':
-    resolution: {integrity: sha512-2T7VOk1vjtC+vNS3q8+U0NGLiUsMi9groK5Hk8wWFf2E64b7MDafYk8AbFU17Sq8LhjWRrXUrQ5W/d0tkQia8Q==}
+  '@sanity/vanilla-extract-tsdown-plugin@0.2.9':
+    resolution: {integrity: sha512-gwuCllhMu4nvcpTCQY0MPdBeAg8uIEvX4Dj4uKvZ40TNVNMHwv3bEUaAquPePGYTSMQg6W0nJz6PoXopW84ATQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       tsdown: ^0.22.5
@@ -2857,8 +2857,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@yuku-parser/binding-darwin-arm64@0.8.0':
+    resolution: {integrity: sha512-04AakSJhI4mPrqhZzXdFyaEDh0YkfeqbnyYY3aCrmxeWfR/Xr8+kFn5sh+wZYN/5HatPniELKHixJuUCUyfBvg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@yuku-parser/binding-darwin-x64@0.7.4':
     resolution: {integrity: sha512-9bHrGQUot2vWTg0YTdyIBHGd38fy2BSQH1WaqUDVuNqSn7HffrTUzWOgbaWRNd5GTOvDdrt9SDZIG7nfqzeBtg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@yuku-parser/binding-darwin-x64@0.8.0':
+    resolution: {integrity: sha512-BQJGI9bDeyb/X2rwhtXoBTQ9EtbkJtteX6C7cZ9jow0pqqmoOufgHPP2+m65GLk2eVNCBcfl3xlTGpJ7RFcviw==}
     cpu: [x64]
     os: [darwin]
 
@@ -2867,8 +2877,19 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@yuku-parser/binding-freebsd-x64@0.8.0':
+    resolution: {integrity: sha512-04hmgnU152wya88raI+RQhxZPgwXcHbfdNZLu3x5ggKnJVHLD8xZZLcWIKSs59CiEXL6PKVX1/cx8GoTYlaCaQ==}
+    cpu: [x64]
+    os: [freebsd]
+
   '@yuku-parser/binding-linux-arm-gnu@0.7.4':
     resolution: {integrity: sha512-j3s3LJxEbOyP58hmzuXpJlKzgxaswuOTu8nAbDpE119b5W3gP1SW+HndLscGUOACpyMdH5WJ6gBHRxq0HCRVBw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm-gnu@0.8.0':
+    resolution: {integrity: sha512-+cuJWUK13lwce721XGRjz7izSr2Q1U0RlHkDzdkohWpRWlttTqRdxNnaW13nDc47GBDrNsXMHx+KLcebeOeeGg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -2879,8 +2900,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@yuku-parser/binding-linux-arm-musl@0.8.0':
+    resolution: {integrity: sha512-rOVPRqt9cm1YP/wPV+yyZh0FYr6UR/wm/BXslvLuge0LDewVvDrm/AxcDrwWuPAu61Nzdg2rMVfcNnrplCbC1w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
   '@yuku-parser/binding-linux-arm64-gnu@0.7.4':
     resolution: {integrity: sha512-Hi3w0et5mu3i7S+qE0UgOev4RqJ/U9DW8xn79t4nttiICYCx3NveC0Goo78uqzxttsDI3hfRY43lrrF26svqcw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.0':
+    resolution: {integrity: sha512-pAoIozKr6E+ptpaQz4CZv1O7cay2f4m7kbd+DSQug5MKdUBTZZ18GdWSPvq0fwQYraH9hZlyLqrMaeP5W/ncrA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2891,8 +2924,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@yuku-parser/binding-linux-arm64-musl@0.8.0':
+    resolution: {integrity: sha512-JCAg50ahXuYlrsIi1jmymX9X/9B0JYBRroAHnYttN44tAvCo1PFqukHrw1up6HvEOoLA0OjlM0Zwh60u3Gc/Zg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@yuku-parser/binding-linux-x64-gnu@0.7.4':
     resolution: {integrity: sha512-j5pt0LyDGxCzfoqRTR3cmMG21+bgSxIufAzJXFOWXkbg/22Ih51eGEsbInnSD5Q9FvJ3ooIn/jfok0dBdhudnA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-x64-gnu@0.8.0':
+    resolution: {integrity: sha512-tEeVQ14etp7lpUqXzq+X5AlQzFH+m3TVDiCKIq17zxnxJ117DOVvoveWSkSMt/lj68z48SvZUMHe7xLvqtO1lg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -2903,8 +2948,19 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@yuku-parser/binding-linux-x64-musl@0.8.0':
+    resolution: {integrity: sha512-+UGRYnF37nnbZNMsMjSGDXKUTIxYUmbbk3Lzib88sLK7kg2y80vjchYYoYsDUK9kAgqPWyA9hKGURHy/Kk9Few==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@yuku-parser/binding-win32-arm64@0.7.4':
     resolution: {integrity: sha512-1xhYwOLo9TjppHHwNYi3X/dGgOvnj9xh62jpgP4U8nEtTGA70NtJDCkN45pRQdU3B6/U7oQj1T4esP3aFJg6BA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@yuku-parser/binding-win32-arm64@0.8.0':
+    resolution: {integrity: sha512-l+7Va9/sX1ccRjzjJj6MR0arKsvHB5b419+pKbwzn+/18A/xfccWqmxXrn0C0NyVLlbEb3AV9Is+AbF72O85yA==}
     cpu: [arm64]
     os: [win32]
 
@@ -2913,8 +2969,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@yuku-parser/binding-win32-x64@0.8.0':
+    resolution: {integrity: sha512-dolKDTJv2xrWowDBEkvSaDvCsVFZOA7DCUuD+7DatglS68WbuxS4LudU5bzSeAOL5vgPpyGm82469cMLnL+6vQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@yuku-toolchain/types@0.7.4':
     resolution: {integrity: sha512-iUFXr+UnUJjzVLNI6GIv07poi9NwcG5hTBJSheJh3SdpkYpIjCl9kAGe7dbJMHn5sXeceCL4H12pKa0b6pkouQ==}
+
+  '@yuku-toolchain/types@0.8.0':
+    resolution: {integrity: sha512-hL/raFM5V9UT2lVE/lIWDTWvANqSB8TvMVp+PgICehBa96KhTl/UpGm370JXaacukR+QnaHM2Yv6O/UcrzAFGg==}
 
   acorn-loose@8.5.2:
     resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
@@ -5655,11 +5719,17 @@ packages:
   yuku-ast@0.7.4:
     resolution: {integrity: sha512-Pn6e7uZOBczeJ+JIiPGtD4aw6eRflzKrZJmAdeg092RxM9tQtvAkZAbEoknNgYmsB6dGYESvXPQcUE7Nu8ai7Q==}
 
+  yuku-ast@0.8.0:
+    resolution: {integrity: sha512-trBzFsSa6k32vzNUCH6pFhAoTzWD/NifSYOIQ/6v14vXKh7TRhd2vDNIwRguGdXvcyfBNEEGcsfxFHrnJbS+FQ==}
+
   yuku-codegen@0.7.4:
     resolution: {integrity: sha512-bLdC5yzvn507PtU7+kB4CMBLfnvKW1N2m26Vpl1q4Os+FLROnkKTThM7g+clVb+9tHaOlcc6gqQ+rNBY8L/Dxw==}
 
   yuku-parser@0.7.4:
     resolution: {integrity: sha512-HveMyhZPQQfR4z3xskXv5hHJW9g0KIESZW6JvUZv7Jn52FfMFUhCYL77KHBtnWGFti0KrKeTHMZVTY5AUVgFAA==}
+
+  yuku-parser@0.8.0:
+    resolution: {integrity: sha512-obrazyE8Cyh79xTQS9wv44khnhvkXG1CDSSy0bg+Pjjla+iXkKXK2b6+LTYXSN3qvVfQxc0MN5qhNKYr9sl3Zw==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -8308,12 +8378,12 @@ snapshots:
 
   '@sanity/tsconfig@2.2.1': {}
 
-  '@sanity/tsdown-config@0.19.6(@babel/runtime@7.29.7)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.0)(tsdown@0.22.13(publint@0.3.22)(tsx@4.23.1)(typescript@7.0.2))(typescript@7.0.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@sanity/tsdown-config@0.21.0(@babel/runtime@7.29.7)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.0)(tsdown@0.22.13(publint@0.3.22)(tsx@4.23.1)(typescript@7.0.2))(typescript@7.0.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@sanity/browserslist-config': 1.0.5
-      '@sanity/vanilla-extract-tsdown-plugin': 0.2.8(rolldown@1.2.0)(tsdown@0.22.13(publint@0.3.22)(tsx@4.23.1)(typescript@7.0.2))
+      '@sanity/vanilla-extract-tsdown-plugin': 0.2.9(rolldown@1.2.0)(tsdown@0.22.13(publint@0.3.22)(tsx@4.23.1)(typescript@7.0.2))
       '@vitejs/plugin-react': 6.0.4(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       browserslist: 4.28.7
       lightningcss: 1.33.0
@@ -8370,27 +8440,27 @@ snapshots:
     dependencies:
       uuid: 11.1.1
 
-  '@sanity/vanilla-extract-integration@0.1.5':
+  '@sanity/vanilla-extract-integration@0.1.6':
     dependencies:
       '@vanilla-extract/css': 1.21.1
       javascript-stringify: 2.1.0
       rolldown: 1.2.0
-      yuku-parser: 0.7.4
+      yuku-parser: 0.8.0
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@sanity/vanilla-extract-rolldown-plugin@0.3.2(rolldown@1.2.0)':
+  '@sanity/vanilla-extract-rolldown-plugin@0.3.3(rolldown@1.2.0)':
     dependencies:
-      '@sanity/vanilla-extract-integration': 0.1.5
+      '@sanity/vanilla-extract-integration': 0.1.6
       lightningcss: 1.33.0
     optionalDependencies:
       rolldown: 1.2.0
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@sanity/vanilla-extract-tsdown-plugin@0.2.8(rolldown@1.2.0)(tsdown@0.22.13(publint@0.3.22)(tsx@4.23.1)(typescript@7.0.2))':
+  '@sanity/vanilla-extract-tsdown-plugin@0.2.9(rolldown@1.2.0)(tsdown@0.22.13(publint@0.3.22)(tsx@4.23.1)(typescript@7.0.2))':
     dependencies:
-      '@sanity/vanilla-extract-rolldown-plugin': 0.3.2(rolldown@1.2.0)
+      '@sanity/vanilla-extract-rolldown-plugin': 0.3.3(rolldown@1.2.0)
       tsdown: 0.22.13(publint@0.3.22)(tsx@4.23.1)(typescript@7.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -8761,37 +8831,72 @@ snapshots:
   '@yuku-parser/binding-darwin-arm64@0.7.4':
     optional: true
 
+  '@yuku-parser/binding-darwin-arm64@0.8.0':
+    optional: true
+
   '@yuku-parser/binding-darwin-x64@0.7.4':
+    optional: true
+
+  '@yuku-parser/binding-darwin-x64@0.8.0':
     optional: true
 
   '@yuku-parser/binding-freebsd-x64@0.7.4':
     optional: true
 
+  '@yuku-parser/binding-freebsd-x64@0.8.0':
+    optional: true
+
   '@yuku-parser/binding-linux-arm-gnu@0.7.4':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-gnu@0.8.0':
     optional: true
 
   '@yuku-parser/binding-linux-arm-musl@0.7.4':
     optional: true
 
+  '@yuku-parser/binding-linux-arm-musl@0.8.0':
+    optional: true
+
   '@yuku-parser/binding-linux-arm64-gnu@0.7.4':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.0':
     optional: true
 
   '@yuku-parser/binding-linux-arm64-musl@0.7.4':
     optional: true
 
+  '@yuku-parser/binding-linux-arm64-musl@0.8.0':
+    optional: true
+
   '@yuku-parser/binding-linux-x64-gnu@0.7.4':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-gnu@0.8.0':
     optional: true
 
   '@yuku-parser/binding-linux-x64-musl@0.7.4':
     optional: true
 
+  '@yuku-parser/binding-linux-x64-musl@0.8.0':
+    optional: true
+
   '@yuku-parser/binding-win32-arm64@0.7.4':
+    optional: true
+
+  '@yuku-parser/binding-win32-arm64@0.8.0':
     optional: true
 
   '@yuku-parser/binding-win32-x64@0.7.4':
     optional: true
 
+  '@yuku-parser/binding-win32-x64@0.8.0':
+    optional: true
+
   '@yuku-toolchain/types@0.7.4': {}
+
+  '@yuku-toolchain/types@0.8.0': {}
 
   acorn-loose@8.5.2:
     dependencies:
@@ -11468,6 +11573,10 @@ snapshots:
     dependencies:
       '@yuku-toolchain/types': 0.7.4
 
+  yuku-ast@0.8.0:
+    dependencies:
+      '@yuku-toolchain/types': 0.8.0
+
   yuku-codegen@0.7.4:
     dependencies:
       '@yuku-toolchain/types': 0.7.4
@@ -11500,6 +11609,23 @@ snapshots:
       '@yuku-parser/binding-linux-x64-musl': 0.7.4
       '@yuku-parser/binding-win32-arm64': 0.7.4
       '@yuku-parser/binding-win32-x64': 0.7.4
+
+  yuku-parser@0.8.0:
+    dependencies:
+      '@yuku-toolchain/types': 0.8.0
+      yuku-ast: 0.8.0
+    optionalDependencies:
+      '@yuku-parser/binding-darwin-arm64': 0.8.0
+      '@yuku-parser/binding-darwin-x64': 0.8.0
+      '@yuku-parser/binding-freebsd-x64': 0.8.0
+      '@yuku-parser/binding-linux-arm-gnu': 0.8.0
+      '@yuku-parser/binding-linux-arm-musl': 0.8.0
+      '@yuku-parser/binding-linux-arm64-gnu': 0.8.0
+      '@yuku-parser/binding-linux-arm64-musl': 0.8.0
+      '@yuku-parser/binding-linux-x64-gnu': 0.8.0
+      '@yuku-parser/binding-linux-x64-musl': 0.8.0
+      '@yuku-parser/binding-win32-arm64': 0.8.0
+      '@yuku-parser/binding-win32-x64': 0.8.0
 
   zod@4.4.3: {}
 

--- a/src/react-portable-text.tsx
+++ b/src/react-portable-text.tsx
@@ -11,7 +11,7 @@ import {
   spanToPlainText,
 } from '@portabletext/toolkit'
 import type {PortableTextBlock, PortableTextListItemBlock, TypedObject} from '@portabletext/types'
-import {type JSX, type ReactNode, useMemo} from 'react'
+import type {JSX, ReactNode} from 'react'
 
 import {defaultComponents} from './components/defaults'
 import {mergeComponents} from './components/merge'
@@ -50,16 +50,13 @@ export function PortableText<B extends TypedObject = PortableTextBlock>({
   }
   const nested = nestLists(blocks, listNestingMode || LIST_NEST_MODE_HTML)
 
-  const components = useMemo(() => {
-    return componentOverrides
-      ? mergeComponents(defaultComponents, componentOverrides)
-      : defaultComponents
-  }, [componentOverrides])
+  // No manual memoization: the compiled (`default` condition) build gets React Compiler
+  // auto-memoization, and the uncompiled `react-server` build renders exactly once anyway.
+  const components = componentOverrides
+    ? mergeComponents(defaultComponents, componentOverrides)
+    : defaultComponents
 
-  const renderNode = useMemo(
-    () => getNodeRenderer(components, handleMissingComponent),
-    [components, handleMissingComponent],
-  )
+  const renderNode = getNodeRenderer(components, handleMissingComponent)
   const rendered = nested.map((node, index) =>
     renderNode({node: node, index, isInline: false, renderNode}),
   )

--- a/test/next-app/.gitignore
+++ b/test/next-app/.gitignore
@@ -1,0 +1,6 @@
+# Everything in here is produced by `pnpm test:next` (see run.mjs)
+node_modules
+.next
+next-env.d.ts
+pnpm-lock.yaml
+portabletext-react.tgz

--- a/test/next-app/app/client/page.tsx
+++ b/test/next-app/app/client/page.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import {PortableText} from '@portabletext/react'
+import {useState} from 'react'
+
+import {blocks} from '../content'
+
+/**
+ * A client component page: `@portabletext/react` resolves through the `default` export
+ * condition to the React Compiler-optimized build, both in the browser bundle and during SSR.
+ */
+export default function ClientPage() {
+  const [count, setCount] = useState(0)
+  return (
+    <main data-testid="client-page">
+      <button type="button" onClick={() => setCount((current) => current + 1)}>
+        count is {count}
+      </button>
+      <PortableText value={blocks} />
+    </main>
+  )
+}

--- a/test/next-app/app/content.ts
+++ b/test/next-app/app/content.ts
@@ -1,0 +1,34 @@
+import type {PortableTextBlock} from '@portabletext/react'
+
+/**
+ * Rendered by both routes; `run.mjs` asserts the served HTML of each route contains the
+ * heading, the strong mark, the link href and the list item.
+ */
+export const blocks: PortableTextBlock[] = [
+  {
+    _type: 'block',
+    _key: 'heading',
+    style: 'h1',
+    children: [{_type: 'span', _key: 'heading-span', text: 'Portable Text in Next.js', marks: []}],
+  },
+  {
+    _type: 'block',
+    _key: 'paragraph',
+    style: 'normal',
+    markDefs: [{_type: 'link', _key: 'link-def', href: 'https://portabletext.org'}],
+    children: [
+      {_type: 'span', _key: 'paragraph-1', text: 'Rendered with ', marks: []},
+      {_type: 'span', _key: 'paragraph-2', text: 'strong emphasis', marks: ['strong']},
+      {_type: 'span', _key: 'paragraph-3', text: ' and a ', marks: []},
+      {_type: 'span', _key: 'paragraph-4', text: 'link', marks: ['link-def']},
+    ],
+  },
+  {
+    _type: 'block',
+    _key: 'list-item',
+    style: 'normal',
+    listItem: 'bullet',
+    level: 1,
+    children: [{_type: 'span', _key: 'list-span', text: 'a bullet list item', marks: []}],
+  },
+]

--- a/test/next-app/app/layout.tsx
+++ b/test/next-app/app/layout.tsx
@@ -1,0 +1,9 @@
+import type {ReactNode} from 'react'
+
+export default function RootLayout({children}: {children: ReactNode}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/next-app/app/page.tsx
+++ b/test/next-app/app/page.tsx
@@ -1,0 +1,20 @@
+import {PortableText} from '@portabletext/react'
+
+import {blocks} from './content'
+
+// Render at request time so `next start` + fetch exercises the react-server build live -
+// a static prerender would hide resolution failures behind the build step.
+export const dynamic = 'force-dynamic'
+
+/**
+ * A pure React Server Component (no `'use client'` anywhere in its module graph):
+ * `@portabletext/react` must resolve through the `react-server` export condition to the
+ * uncompiled build, since React Compiler output cannot load in the react-server environment.
+ */
+export default function ServerPage() {
+  return (
+    <main data-testid="rsc-page">
+      <PortableText value={blocks} />
+    </main>
+  )
+}

--- a/test/next-app/next.config.ts
+++ b/test/next-app/next.config.ts
@@ -1,0 +1,9 @@
+import type {NextConfig} from 'next'
+
+const config: NextConfig = {
+  // Both the repo root and this app have a pnpm-lock.yaml while `pnpm test:next` runs; pin
+  // the workspace root so Turbopack doesn't infer it from the repo's lockfile.
+  turbopack: {root: __dirname},
+}
+
+export default config

--- a/test/next-app/package.json
+++ b/test/next-app/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "portabletext-react-next-integration",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@portabletext/react": "file:./portabletext-react.tgz",
+    "next": "preview",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/test/next-app/run.mjs
+++ b/test/next-app/run.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * Integration test for the dual React Server Components build, run with `pnpm test:next`.
+ *
+ * Builds the library, packs it with `pnpm pack` (so `publishConfig` applies, exactly like a
+ * publish), installs the tarball into the Next.js app in this directory, and serves a
+ * production build with two routes:
+ *
+ * - `/` is a pure React Server Component page: it must resolve `@portabletext/react` through
+ *   the `react-server` export condition to the uncompiled build. If the compiled build leaks
+ *   into the react-server environment it throws the `Cannot read properties of undefined
+ *   (reading 'H')` TypeError from https://github.com/facebook/react/issues/31702 and the
+ *   route responds 500.
+ * - `/client` is a `'use client'` page: it resolves the `default` condition to the React
+ *   Compiler-optimized build, both for SSR markup and the browser bundle.
+ *
+ * Both routes must respond 200 with the Portable Text content rendered to markup.
+ */
+
+import {spawn, spawnSync} from 'node:child_process'
+import {readFile, rm} from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import {setTimeout as sleep} from 'node:timers/promises'
+import {fileURLToPath} from 'node:url'
+
+const appDir = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(appDir, '../..')
+const tarball = path.join(appDir, 'portabletext-react.tgz')
+const nextBin = path.join(appDir, 'node_modules', 'next', 'dist', 'bin', 'next')
+const port = Number(process.env.PORT || 3411)
+const origin = `http://localhost:${port}`
+
+/** Markup every route must render (deliberately `>text<` shaped so a marker that only shows
+ * up in the serialized RSC payload, not in actual markup, does not count). */
+const contentMarkers = [
+  '>Portable Text in Next.js<',
+  '<strong>strong emphasis</strong>',
+  'href="https://portabletext.org"',
+  '>a bullet list item<',
+]
+
+function run(command, args, cwd) {
+  console.log(`\n$ ${command} ${args.join(' ')}  # in ${path.relative(rootDir, cwd) || '.'}`)
+  const result = spawnSync(command, args, {
+    cwd,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+    env: {...process.env, NEXT_TELEMETRY_DISABLED: '1'},
+  })
+  if (result.status !== 0) {
+    throw new Error(`\`${command} ${args.join(' ')}\` exited with ${result.status}`)
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`)
+  console.log(`ok - ${message}`)
+}
+
+/** The packed artifacts must have the shape consumers install: the `react-server` condition
+ * resolving the uncompiled build ahead of the compiled `default`. */
+async function checkInstalledArtifacts() {
+  const installedDir = path.join(appDir, 'node_modules', '@portabletext', 'react')
+  const manifest = JSON.parse(await readFile(path.join(installedDir, 'package.json'), 'utf8'))
+
+  const rootExport = manifest.exports['.']
+  const conditions = Object.keys(rootExport)
+  assert(
+    rootExport['react-server'] === './dist/index.react-server.js',
+    'exports["."]["react-server"] resolves the uncompiled build',
+  )
+  assert(
+    rootExport.default === './dist/index.js',
+    'exports["."].default resolves the compiled build',
+  )
+  assert(
+    conditions.indexOf('react-server') < conditions.indexOf('default'),
+    'the react-server condition matches ahead of default',
+  )
+
+  const compiled = await readFile(path.join(installedDir, 'dist', 'index.js'), 'utf8')
+  const reactServer = await readFile(
+    path.join(installedDir, 'dist', 'index.react-server.js'),
+    'utf8',
+  )
+  assert(
+    compiled.includes('react/compiler-runtime'),
+    'the compiled build is optimized with React Compiler',
+  )
+  assert(
+    !reactServer.includes('react/compiler-runtime'),
+    'the react-server build does not load the compiler runtime',
+  )
+  assert(
+    !reactServer.includes('useMemo(') && !reactServer.includes('useCallback('),
+    'the react-server build has no memoization at all',
+  )
+}
+
+async function checkRoute(pathname, markers) {
+  const response = await fetch(origin + pathname)
+  const html = await response.text()
+  const problems = []
+  if (response.status !== 200) problems.push(`expected status 200, got ${response.status}`)
+  for (const marker of markers) {
+    if (!html.includes(marker)) problems.push(`missing marker ${JSON.stringify(marker)}`)
+  }
+  if (problems.length > 0) {
+    console.error(`--- response body of GET ${pathname} ---\n${html.slice(0, 4000)}\n---`)
+    throw new Error(`GET ${pathname}: ${problems.join('; ')}`)
+  }
+  console.log(`ok - GET ${pathname} responded 200 with all ${markers.length} markers rendered`)
+}
+
+// Build the library (compiled + react-server variants) and pack it: `pnpm pack` applies
+// `publishConfig`, so the tarball has the conditional `exports` map consumers install.
+run('pnpm', ['build'], rootDir)
+run('pnpm', ['pack', '--out', path.relative(rootDir, tarball)], rootDir)
+
+// Fresh install: a leftover lockfile pins the integrity of a previously packed tarball, and
+// `next@preview` should resolve to the current preview release on every run.
+await rm(path.join(appDir, 'pnpm-lock.yaml'), {force: true})
+await rm(path.join(appDir, 'node_modules'), {recursive: true, force: true})
+await rm(path.join(appDir, '.next'), {recursive: true, force: true})
+run('pnpm', ['install'], appDir)
+
+const nextVersion = JSON.parse(
+  await readFile(path.join(appDir, 'node_modules', 'next', 'package.json'), 'utf8'),
+).version
+console.log(`\nTesting against next@${nextVersion}`)
+
+await checkInstalledArtifacts()
+
+run(process.execPath, [nextBin, 'build'], appDir)
+
+console.log(`\n$ next start -p ${port}  # in ${path.relative(rootDir, appDir)}`)
+const server = spawn(process.execPath, [nextBin, 'start', '-p', String(port)], {
+  cwd: appDir,
+  stdio: ['ignore', 'pipe', 'pipe'],
+  env: {...process.env, NEXT_TELEMETRY_DISABLED: '1'},
+})
+let serverOutput = ''
+server.stdout.on('data', (chunk) => {
+  serverOutput += chunk
+})
+server.stderr.on('data', (chunk) => {
+  serverOutput += chunk
+})
+
+try {
+  // Wait for the server to accept connections (any response counts - assertions come after)
+  const deadline = Date.now() + 60_000
+  for (;;) {
+    try {
+      await fetch(origin)
+      break
+    } catch {
+      if (server.exitCode !== null) {
+        throw new Error(`next start exited with ${server.exitCode} before accepting connections`)
+      }
+      if (Date.now() > deadline) throw new Error('next start did not accept connections in 60s')
+      await sleep(500)
+    }
+  }
+
+  await checkRoute('/', ['data-testid="rsc-page"', ...contentMarkers])
+  await checkRoute('/client', ['data-testid="client-page"', 'count is', ...contentMarkers])
+
+  console.log('\nAll checks passed: the react-server and default builds both render.')
+} catch (error) {
+  if (serverOutput) console.error(`--- next start output ---\n${serverOutput}---`)
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+} finally {
+  server.kill()
+}

--- a/test/next-app/tsconfig.json
+++ b/test/next-app/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "plugins": [{"name": "next"}]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@sanity/tsconfig/strictest",
-  "exclude": ["demo/dist", "dist", "node_modules"],
+  "exclude": ["demo/dist", "dist", "node_modules", "test/next-app"],
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,4 +2,5 @@ import {defineConfig} from '@sanity/tsdown-config'
 
 export default defineConfig({
   tsconfig: './tsconfig.dist.json',
+  reactCompiler: {target: '19', reactServer: true},
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adopts `@sanity/tsdown-config@0.21.0`'s `reactCompiler.reactServer` dual build ([sanity-io/pkg-utils#3143](https://github.com/sanity-io/pkg-utils/pull/3143)): the published `default` build is optimized with React Compiler auto-memoization, and React Server Components resolve an uncompiled build through the `react-server` export condition, since [RSC refuses to load React Compiler output](https://github.com/facebook/react/issues/31702):

```json
".": {
  "types": "./dist/index.d.ts",
  "react-server": "./dist/index.react-server.js",
  "default": "./dist/index.js"
}
```

Both builds come from the same source — the only difference is whether the compiler is applied. The manual `useMemo` calls in `PortableText` are deleted: client components get the compiler's finer-grained auto-memoization instead, and server components render exactly once, so memoization could never pay off there.

**BREAKING (new major):** React 19 is now required — the compiled build loads `react/compiler-runtime`, which only exists in React 19. React 18 consumers stay on `@portabletext/react@6`, which keeps working as-is. There are no API changes, so the regression surface for React 19 consumers upgrading is the build pipeline itself, which the new integration test covers end-to-end.

### Integration test (`pnpm test:next`)

`test/next-app` is a `next@preview` app with two routes, tested against the *packed* artifact so the export conditions actually resolve: the runner builds the library, packs it with `pnpm pack` (applying `publishConfig`, exactly like a publish), installs the tarball into the app, `next build`s and serves it:

- `/` — a pure RSC `page.tsx` (no directive, `force-dynamic` so rendering happens at request time). If the compiled build leaked into the react-server environment this responds 500 with the exact `TypeError: Cannot read properties of undefined (reading 'H')` (verified as a negative control by stripping the condition from a packed tarball).
- `/client` — a `page.tsx` with `'use client'` at the top, rendering the compiled build via SSR and the browser bundle.

Both routes must respond 200 with the Portable Text content rendered to markup. The runner also asserts the installed manifest resolves `react-server` ahead of `default`, and that only the compiled build contains `react/compiler-runtime` (the react-server build contains no memoization at all). CI runs it as a new `Next.js RSC integration` job.

### Testing

- `pnpm test` (72 tests), `pnpm lint`, `pnpm type-check`, `pnpm build` (publint clean) all pass
- `pnpm test:next` passes against `next@16.3.0-preview.x`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c53e7fb-7c84-4345-9f23-a24c9aa5e12c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c53e7fb-7c84-4345-9f23-a24c9aa5e12c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

