### PR TITLE
refactor: use named functions for all default components

### DIFF
--- a/.changeset/named-default-components.md
+++ b/.changeset/named-default-components.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/react': patch
+---
+
+Give default Portable Text components proper function names for React DevTools and React Compiler coverage.

--- a/src/components/defaults.tsx
+++ b/src/components/defaults.tsx
@@ -21,39 +21,35 @@ export function DefaultHardBreak(): JSX.Element {
   return <br />
 }
 
-export function DefaultNormal({
-  children,
-}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+function DefaultNormal({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
   return <p>{children}</p>
 }
 
-export function DefaultBlockquote({
-  children,
-}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+function DefaultBlockquote({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
   return <blockquote>{children}</blockquote>
 }
 
-export function DefaultH1({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+function DefaultH1({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
   return <h1>{children}</h1>
 }
 
-export function DefaultH2({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+function DefaultH2({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
   return <h2>{children}</h2>
 }
 
-export function DefaultH3({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+function DefaultH3({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
   return <h3>{children}</h3>
 }
 
-export function DefaultH4({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+function DefaultH4({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
   return <h4>{children}</h4>
 }
 
-export function DefaultH5({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+function DefaultH5({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
   return <h5>{children}</h5>
 }
 
-export function DefaultH6({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+function DefaultH6({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
   return <h6>{children}</h6>
 }
 

--- a/src/components/defaults.tsx
+++ b/src/components/defaults.tsx
@@ -1,8 +1,10 @@
+import type {PortableTextBlock} from '@portabletext/types'
 import type {JSX} from 'react'
 
 import type {
   DefaultPortableTextBlockStyle,
   PortableTextBlockComponent,
+  PortableTextComponentProps,
   PortableTextReactComponents,
 } from '../types'
 import {DefaultListItem, defaultLists} from './list'
@@ -15,18 +17,56 @@ import {
   DefaultUnknownType,
 } from './unknown'
 
-export const DefaultHardBreak = (): JSX.Element => <br />
+export function DefaultHardBreak(): JSX.Element {
+  return <br />
+}
+
+export function DefaultNormal({
+  children,
+}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+  return <p>{children}</p>
+}
+
+export function DefaultBlockquote({
+  children,
+}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+  return <blockquote>{children}</blockquote>
+}
+
+export function DefaultH1({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+  return <h1>{children}</h1>
+}
+
+export function DefaultH2({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+  return <h2>{children}</h2>
+}
+
+export function DefaultH3({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+  return <h3>{children}</h3>
+}
+
+export function DefaultH4({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+  return <h4>{children}</h4>
+}
+
+export function DefaultH5({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+  return <h5>{children}</h5>
+}
+
+export function DefaultH6({children}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
+  return <h6>{children}</h6>
+}
 
 export const defaultBlockStyles: Record<DefaultPortableTextBlockStyle, PortableTextBlockComponent> =
   {
-    normal: ({children}) => <p>{children}</p>,
-    blockquote: ({children}) => <blockquote>{children}</blockquote>,
-    h1: ({children}) => <h1>{children}</h1>,
-    h2: ({children}) => <h2>{children}</h2>,
-    h3: ({children}) => <h3>{children}</h3>,
-    h4: ({children}) => <h4>{children}</h4>,
-    h5: ({children}) => <h5>{children}</h5>,
-    h6: ({children}) => <h6>{children}</h6>,
+    normal: DefaultNormal,
+    blockquote: DefaultBlockquote,
+    h1: DefaultH1,
+    h2: DefaultH2,
+    h3: DefaultH3,
+    h4: DefaultH4,
+    h5: DefaultH5,
+    h6: DefaultH6,
   }
 
 export const defaultComponents: PortableTextReactComponents = {

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -8,13 +8,13 @@ import type {
   ReactPortableTextList,
 } from '../types'
 
-export function DefaultNumberList({
+function DefaultNumberList({
   children,
 }: PortableTextComponentProps<ReactPortableTextList>): JSX.Element {
   return <ol>{children}</ol>
 }
 
-export function DefaultBulletList({
+function DefaultBulletList({
   children,
 }: PortableTextComponentProps<ReactPortableTextList>): JSX.Element {
   return <ul>{children}</ul>

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -1,12 +1,32 @@
+import type {PortableTextListItemBlock} from '@portabletext/types'
+import type {JSX} from 'react'
+
 import type {
   DefaultPortableTextListItem,
+  PortableTextComponentProps,
   PortableTextListComponent,
-  PortableTextListItemComponent,
+  ReactPortableTextList,
 } from '../types'
 
-export const defaultLists: Record<DefaultPortableTextListItem, PortableTextListComponent> = {
-  number: ({children}) => <ol>{children}</ol>,
-  bullet: ({children}) => <ul>{children}</ul>,
+export function DefaultNumberList({
+  children,
+}: PortableTextComponentProps<ReactPortableTextList>): JSX.Element {
+  return <ol>{children}</ol>
 }
 
-export const DefaultListItem: PortableTextListItemComponent = ({children}) => <li>{children}</li>
+export function DefaultBulletList({
+  children,
+}: PortableTextComponentProps<ReactPortableTextList>): JSX.Element {
+  return <ul>{children}</ul>
+}
+
+export function DefaultListItem({
+  children,
+}: PortableTextComponentProps<PortableTextListItemBlock>): JSX.Element {
+  return <li>{children}</li>
+}
+
+export const defaultLists: Record<DefaultPortableTextListItem, PortableTextListComponent> = {
+  number: DefaultNumberList,
+  bullet: DefaultBulletList,
+}

--- a/src/components/marks.tsx
+++ b/src/components/marks.tsx
@@ -14,27 +14,27 @@ interface DefaultLinkMark extends TypedObject {
 
 const underlineStyle = {textDecoration: 'underline'}
 
-export function DefaultEm({children}: PortableTextMarkComponentProps): JSX.Element {
+function DefaultEm({children}: PortableTextMarkComponentProps): JSX.Element {
   return <em>{children}</em>
 }
 
-export function DefaultStrong({children}: PortableTextMarkComponentProps): JSX.Element {
+function DefaultStrong({children}: PortableTextMarkComponentProps): JSX.Element {
   return <strong>{children}</strong>
 }
 
-export function DefaultCode({children}: PortableTextMarkComponentProps): JSX.Element {
+function DefaultCode({children}: PortableTextMarkComponentProps): JSX.Element {
   return <code>{children}</code>
 }
 
-export function DefaultUnderline({children}: PortableTextMarkComponentProps): JSX.Element {
+function DefaultUnderline({children}: PortableTextMarkComponentProps): JSX.Element {
   return <span style={underlineStyle}>{children}</span>
 }
 
-export function DefaultStrikeThrough({children}: PortableTextMarkComponentProps): JSX.Element {
+function DefaultStrikeThrough({children}: PortableTextMarkComponentProps): JSX.Element {
   return <del>{children}</del>
 }
 
-export function DefaultLink({
+function DefaultLink({
   children,
   value,
 }: PortableTextMarkComponentProps<DefaultLinkMark>): JSX.Element {

--- a/src/components/marks.tsx
+++ b/src/components/marks.tsx
@@ -1,23 +1,51 @@
 import type {TypedObject} from '@portabletext/types'
+import type {JSX} from 'react'
 
-import type {DefaultPortableTextMark, PortableTextMarkComponent} from '../types'
+import type {
+  DefaultPortableTextMark,
+  PortableTextMarkComponent,
+  PortableTextMarkComponentProps,
+} from '../types'
 
-interface DefaultLink extends TypedObject {
+interface DefaultLinkMark extends TypedObject {
   _type: 'link'
   href: string
 }
 
-const link: PortableTextMarkComponent<DefaultLink> = ({children, value}) => (
-  <a href={value?.href}>{children}</a>
-)
-
 const underlineStyle = {textDecoration: 'underline'}
 
+export function DefaultEm({children}: PortableTextMarkComponentProps): JSX.Element {
+  return <em>{children}</em>
+}
+
+export function DefaultStrong({children}: PortableTextMarkComponentProps): JSX.Element {
+  return <strong>{children}</strong>
+}
+
+export function DefaultCode({children}: PortableTextMarkComponentProps): JSX.Element {
+  return <code>{children}</code>
+}
+
+export function DefaultUnderline({children}: PortableTextMarkComponentProps): JSX.Element {
+  return <span style={underlineStyle}>{children}</span>
+}
+
+export function DefaultStrikeThrough({children}: PortableTextMarkComponentProps): JSX.Element {
+  return <del>{children}</del>
+}
+
+export function DefaultLink({
+  children,
+  value,
+}: PortableTextMarkComponentProps<DefaultLinkMark>): JSX.Element {
+  return <a href={value?.href}>{children}</a>
+}
+
 export const defaultMarks: Record<DefaultPortableTextMark, PortableTextMarkComponent> = {
-  em: ({children}) => <em>{children}</em>,
-  strong: ({children}) => <strong>{children}</strong>,
-  code: ({children}) => <code>{children}</code>,
-  underline: ({children}) => <span style={underlineStyle}>{children}</span>,
-  'strike-through': ({children}) => <del>{children}</del>,
-  link,
+  em: DefaultEm,
+  strong: DefaultStrong,
+  code: DefaultCode,
+  underline: DefaultUnderline,
+  'strike-through': DefaultStrikeThrough,
+  link: DefaultLink,
 }

--- a/src/components/unknown.tsx
+++ b/src/components/unknown.tsx
@@ -1,35 +1,45 @@
-import type {PortableTextReactComponents} from '../types'
+import type {PortableTextBlock, PortableTextListItemBlock} from '@portabletext/types'
+import type {JSX} from 'react'
+
+import type {
+  PortableTextComponentProps,
+  PortableTextMarkComponentProps,
+  ReactPortableTextList,
+  UnknownNodeType,
+} from '../types'
 import {unknownTypeWarning} from '../warnings'
 
 const hidden = {display: 'none'}
 
-export const DefaultUnknownType: PortableTextReactComponents['unknownType'] = ({
+export function DefaultUnknownType({
   value,
   isInline,
-}) => {
+}: PortableTextComponentProps<UnknownNodeType>): JSX.Element {
   const warning = unknownTypeWarning(value._type)
   return isInline ? <span style={hidden}>{warning}</span> : <div style={hidden}>{warning}</div>
 }
 
-export const DefaultUnknownMark: PortableTextReactComponents['unknownMark'] = ({
+export function DefaultUnknownMark({
   markType,
   children,
-}) => {
+}: PortableTextMarkComponentProps): JSX.Element {
   return <span className={`unknown__pt__mark__${markType}`}>{children}</span>
 }
 
-export const DefaultUnknownBlockStyle: PortableTextReactComponents['unknownBlockStyle'] = ({
+export function DefaultUnknownBlockStyle({
   children,
-}) => {
+}: PortableTextComponentProps<PortableTextBlock>): JSX.Element {
   return <p>{children}</p>
 }
 
-export const DefaultUnknownList: PortableTextReactComponents['unknownList'] = ({children}) => {
+export function DefaultUnknownList({
+  children,
+}: PortableTextComponentProps<ReactPortableTextList>): JSX.Element {
   return <ul>{children}</ul>
 }
 
-export const DefaultUnknownListItem: PortableTextReactComponents['unknownListItem'] = ({
+export function DefaultUnknownListItem({
   children,
-}) => {
+}: PortableTextComponentProps<PortableTextListItemBlock>): JSX.Element {
   return <li>{children}</li>
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Every default Portable Text component is now a named function declaration instead of an anonymous/inline arrow.

**Why**
- React DevTools shows useful names (`DefaultH1`, `DefaultEm`, …) instead of anonymous components
- React Compiler can optimize named function components more reliably

**Changes**
- `defaults.tsx` — block styles + hard break (`DefaultNormal`, `DefaultH1`–`DefaultH6`, `DefaultBlockquote`, `DefaultHardBreak`)
- `marks.tsx` — decorators + link (`DefaultEm`, `DefaultStrong`, `DefaultCode`, `DefaultUnderline`, `DefaultStrikeThrough`, `DefaultLink`)
- `list.tsx` — lists + list item (`DefaultNumberList`, `DefaultBulletList`, `DefaultListItem`)
- `unknown.tsx` — unknown fallbacks converted from const arrows to named functions

Newly introduced helpers stay module-private; only previously exported symbols (`DefaultHardBreak`, `DefaultListItem`, unknown fallbacks, and the `default*` maps) remain exported.

No behavior or API changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb8f780d-3e7c-4fb4-a16f-e70eb5800633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb8f780d-3e7c-4fb4-a16f-e70eb5800633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

